### PR TITLE
feat: run on Linux — /proc/mounts, sysfs identity, probe tools, clipboard

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -589,13 +589,26 @@ The two invariants do not move across platforms: reachability is decided by
 the destination proving it is itself, never by the path existing, and nothing
 lands in a target except through rsync.
 
-Keeping the first of those honest costs one more thing on Linux than it does
-on macOS. `diskutil` answers for essentially every local volume, so the
-mount-source fallback in `identify` is rare there; where no uuid is published
-the fallback is the device path, and `/dev/sdb1` is a slot in this boot's
-enumeration order rather than a name for a disk — a different disk in the
-same port answers to it. So the two identity kinds are not interchangeable
-proof: a `volume-uuid` stands alone, a `mount-source` is checked against the
-sentinel as well, and adding a target that resolves to one writes a sentinel
-so there is something to check. The sentinel is the proof that survives the
-disk being swapped, which is why it is the one §2 calls the most important.
+Keeping the first of those honest turns on a distinction macOS never had to
+draw. `identify` returns one of three things, and only two of them are names
+for a volume: a filesystem uuid, a network share's host and export, or — when
+the kernel publishes no uuid — the device path. `/dev/sdb1` is a slot in this
+boot's enumeration order, and a different disk in the same port answers to
+it, so it is not proof of anything. `diskutil` answers for essentially every
+local volume and udev for essentially every Linux one, which makes that
+fallback rare on both; rare is not never, and the fallback used to be
+accepted as proof outright.
+
+So reachability asks `identityIsProof` first. A uuid or a share name resolves
+on its own, as before. A device path is still checked — it catches the volume
+being unmounted — and then handed to the sentinel, whose answer is returned:
+the sentinel is the proof that survives the disk being swapped, which is why
+§2 calls it the most important one, and where one exists it should decide.
+
+With no sentinel to hand it to, the device path is accepted. That is the
+weakest branch and it is a deliberate one: refusing makes syncy unusable on a
+machine that publishes no uuid, and a tool that will not run is not safer
+than one that runs with a proof it has labelled as weak. Adding such a target
+says so on the line it prints, and `syncy sentinel` is the upgrade. What is
+not allowed is the old behaviour — treating it as equal to a uuid and never
+reading the sentinel at all.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -568,3 +568,23 @@ what this tool exists to detect, so it should not be the thing that creates one.
 
 Phase 1 alone already answers both original questions; phases 2–5 are ergonomics
 and packaging.
+
+## 10. Platforms — macOS and Linux
+
+macOS is the platform every constraint in §0 was measured on, and remains the
+reference. Linux support maps the same decisions onto the kernel's own
+interfaces, and assumes nothing new:
+
+| Concern | macOS | Linux |
+|---|---|---|
+| Mount table | `/sbin/mount` (BSD format, cached 1 s) | `/proc/mounts` — already in memory; no spawn, and no stall enumerating a dead share |
+| Volume identity | `diskutil` volume UUID | sysfs `uuid`/`partuuid` per block device, with a devnum route for namespaced `/sys`; the device path as mount-source when the kernel publishes nothing |
+| Local vs share | the kernel's `local` flag | network fstypes first, then `/dev/...` device versus pseudo-filesystem |
+| External vs internal | `diskutil` device location | `/sys/block/<name>/removable`; a loop device is `unknown`, not either — it backs a mounted image, not hardware, and the vocabulary has no word for images |
+| Capability probe | `xattr`, `chmod +a`, `ls -le` | `setfattr`/`getfattr`, `setfacl`/`getfacl`; a missing tool is reported as *unmeasurable* and drops the flag — the safe outcome, honestly labelled |
+| rsync | Homebrew and MacPorts only — never `/usr/bin`, which is openrsync | the distribution `/usr/bin/rsync`; `checkBuild` still refuses anything older than 3.x |
+| Clipboard | `/usr/bin/pbcopy` | first of `wl-copy`, `xclip`, `xsel`; absence is reported, not thrown |
+
+The two invariants do not move across platforms: reachability is decided by
+the destination proving it is itself, never by the path existing, and nothing
+lands in a target except through rsync.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -578,9 +578,9 @@ interfaces, and assumes nothing new:
 | Concern | macOS | Linux |
 |---|---|---|
 | Mount table | `/sbin/mount` (BSD format, cached 1 s) | `/proc/mounts` — already in memory; no spawn, and no stall enumerating a dead share |
-| Volume identity | `diskutil` volume UUID | sysfs `uuid`/`partuuid` per block device, with a devnum route for namespaced `/sys`; the device path as mount-source when the kernel publishes nothing |
+| Volume identity | `diskutil` volume UUID | udev's `/dev/disk/by-uuid` (then `by-partuuid`), matched by resolving both sides to the same device node; sysfs `uuid` last, for the classes that publish their own (NVMe namespace, device-mapper). A filesystem uuid is in the superblock, never in `/sys` |
 | Local vs share | the kernel's `local` flag | network fstypes first, then `/dev/...` device versus pseudo-filesystem |
-| External vs internal | `diskutil` device location | `/sys/block/<name>/removable`; a loop device is `unknown`, not either — it backs a mounted image, not hardware, and the vocabulary has no word for images |
+| External vs internal | `diskutil` device location | `removable`, read from the device's *disk* — `/sys/class/block` holds partitions too, and the bit is published per disk — a loop device is `unknown`, not either: it backs a mounted image, not hardware, and the vocabulary has no word for images |
 | Capability probe | `xattr`, `chmod +a`, `ls -le` | `setfattr`/`getfattr`, `setfacl`/`getfacl`; a missing tool is reported as *unmeasurable* and drops the flag — the safe outcome, honestly labelled |
 | rsync | Homebrew and MacPorts only — never `/usr/bin`, which is openrsync | the distribution `/usr/bin/rsync`; `checkBuild` still refuses anything older than 3.x |
 | Clipboard | `/usr/bin/pbcopy` | first of `wl-copy`, `xclip`, `xsel`; absence is reported, not thrown |
@@ -588,3 +588,14 @@ interfaces, and assumes nothing new:
 The two invariants do not move across platforms: reachability is decided by
 the destination proving it is itself, never by the path existing, and nothing
 lands in a target except through rsync.
+
+Keeping the first of those honest costs one more thing on Linux than it does
+on macOS. `diskutil` answers for essentially every local volume, so the
+mount-source fallback in `identify` is rare there; where no uuid is published
+the fallback is the device path, and `/dev/sdb1` is a slot in this boot's
+enumeration order rather than a name for a disk — a different disk in the
+same port answers to it. So the two identity kinds are not interchangeable
+proof: a `volume-uuid` stands alone, a `mount-source` is checked against the
+sentinel as well, and adding a target that resolves to one writes a sentinel
+so there is something to check. The sentinel is the proof that survives the
+disk being swapped, which is why it is the one §2 calls the most important.

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,0 +1,44 @@
+import { existsSync } from "node:fs";
+import { IS_MACOS } from "./platform.ts";
+
+/**
+ * Putting the plan on the clipboard.
+ *
+ * macOS has pbcopy in /usr/bin. Linux has no standard clipboard binary: the
+ * Wayland world uses wl-clipboard and the X11 world uses xclip or xsel, so the
+ * first one that is installed is used. Every path is absolute and pinned, like
+ * every other binary syncy runs.
+ *
+ * Copying is a convenience, and its absence is reported rather than thrown: a
+ * machine without a clipboard tool must still be able to read the plan.
+ */
+export async function copyToClipboard(text: string): Promise<string> {
+  const candidates: readonly (readonly string[])[] = IS_MACOS
+    ? [["/usr/bin/pbcopy"]]
+    : [
+        ["/usr/bin/wl-copy"],
+        ["/usr/bin/xclip", "-selection", "clipboard"],
+        ["/bin/xclip", "-selection", "clipboard"],
+        ["/usr/bin/xsel", "-ib"],
+        ["/bin/xsel", "-ib"],
+      ];
+
+  for (const argv of candidates) {
+    const bin = argv[0];
+    if (bin === undefined || !existsSync(bin)) continue;
+    try {
+      const proc = Bun.spawn(argv as string[], {
+        stdin: new TextEncoder().encode(text),
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+      const code = await proc.exited;
+      if (code === 0) return "plan copied to the clipboard";
+    } catch {
+      // The tool exists but failed (no display, no clipboard): try the next.
+    }
+  }
+  return IS_MACOS
+    ? "could not reach pbcopy"
+    : "no clipboard tool found — install wl-clipboard or xclip";
+}

--- a/src/fstype.ts
+++ b/src/fstype.ts
@@ -97,3 +97,85 @@ export function modifyWindowFor(fstype: string): number {
   if (f.includes("exfat") || f.includes("msdos") || f.includes("fat")) return 2;
   return 0;
 }
+
+export const PSEUDO_FSTYPES: ReadonlySet<string> = new Set([
+  "tmpfs",
+  "devtmpfs",
+  "devpts",
+  "proc",
+  "sysfs",
+  "cgroup",
+  "cgroup2",
+  "pstore",
+  "securityfs",
+  "debugfs",
+  "tracefs",
+  "configfs",
+  "fusectl",
+  "mqueue",
+  "hugetlbfs",
+  "bpf",
+  "autofs",
+  "binfmt_misc",
+  "rpc_pipefs",
+  "nsfs",
+  "ramfs",
+  "efivarfs",
+  "selinuxfs",
+  "swap",
+  "overlay",
+  "squashfs",
+  "fuse",
+  "fuse.lxcfs",
+  "fuse.portal",
+]);
+
+/**
+ * Parses Linux `/proc/mounts`: `device mountpoint fstype options 0 0`.
+ *
+ * A space, tab or newline inside a mount point is octal-escaped (`\\040`,
+ * `\\010`, `\\012`), so the line is split on raw whitespace first and each
+ * field is unescaped afterwards — splitting on spaces alone would mangle a
+ * mount point that contains one, and the unescape has to happen per field.
+ *
+ * `/proc/mounts` carries no `local` flag the way BSD `mount` does, so it is
+ * derived: a network filesystem's device is the remote source
+ * (`//server/share`, `host:/export`), never `/dev/...`, and everything that
+ * is neither a block device nor a known pseudo-filesystem (zfs, a FUSE remote)
+ * is reported as not local, which is the conservative answer.
+ */
+export function parseProcMounts(text: string): MountEntry[] {
+  // Not named `unescape`: that is a deprecated global, and shadowing it is
+  // exactly the kind of accident this parser is written to avoid.
+  const unescapeField = (field: string): string =>
+    field.replace(/\\([0-7]{3})/g, (_, octal: string) =>
+      String.fromCharCode(Number.parseInt(octal, 8)),
+    );
+  const entries: MountEntry[] = [];
+  for (const line of text.split("\n")) {
+    const parts = line.trim().split(/\s+/).map(unescapeField);
+    if (parts.length < 3) continue;
+    const device = parts[0]!;
+    const mountPoint = parts[1]!;
+    const fstype = parts[2]!;
+    // A real line always has a device, an absolute mount point and a type.
+    // Requiring the leading slash is what keeps "not a mount line" from
+    // parsing as a mount at `a` of type `mount`.
+    if (device === "" || mountPoint === "" || fstype === "" || !mountPoint.startsWith("/"))
+      continue;
+    const flags = (parts[3] ?? "")
+      .split(",")
+      .map((f) => f.trim())
+      .filter((f) => f !== "");
+    entries.push({
+      device,
+      mountPoint,
+      fstype,
+      flags,
+      local: device.startsWith("/dev/") || PSEUDO_FSTYPES.has(fstype.toLowerCase()),
+    });
+  }
+  return entries;
+}
+
+/** The longest matching mount point wins, since mounts nest. */

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,26 @@
+import { existsSync } from "node:fs";
+
+/**
+ * One place to answer "which operating system is running syncy".
+ *
+ * Everything that differs between macOS and Linux — where rsync lives, where
+ * the mount table lives, how a volume is identified, which probe tools exist —
+ * branches on this. Keeping the branch in one module means the per-module code
+ * states its two platform behaviours side by side instead of scattering
+ * process.platform checks.
+ */
+export const IS_MACOS = process.platform === "darwin";
+export const IS_LINUX = process.platform === "linux";
+
+/**
+ * The first candidate that exists, or null.
+ *
+ * The same pinning discipline rsync gets: absolute paths only, never resolved
+ * from PATH, so a planted executable cannot be pulled into the process.
+ */
+export function resolveBin(candidates: readonly string[]): string | null {
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  return null;
+}

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -1,5 +1,6 @@
 import { rmSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { IS_MACOS, resolveBin } from "./platform.ts";
 import { DEFAULT_RSYNC } from "./rsync.ts";
 import { makeStaging, removeStaging, stageFile } from "./staging.ts";
 
@@ -37,8 +38,70 @@ export interface ProbeResult {
   readonly detail: string;
 }
 
-const XATTR_NAME = "com.syncy.probe";
 const XATTR_VALUE = "v1";
+
+/**
+ * The probe's extended attribute, by platform namespace.
+ *
+ * macOS stores it as `com.syncy.probe`. Linux allows unprivileged processes to
+ * write only the `user.` namespace, and a dot in the name after the prefix is
+ * refused by the kernel, hence the single word.
+ */
+const XATTR_NAME = IS_MACOS ? "com.syncy.probe" : "user.syncyprobe";
+
+/**
+ * The tools a capability probe needs, in argv form.
+ *
+ * macOS answers with the BSD tools: `xattr` for extended attributes, and
+ * `chmod +a` / `ls -le` for ACLs. Linux uses the `attr` and `acl` packages —
+ * `setfattr`/`getfattr` and `setfacl`/`getfacl`. Both are pinned to absolute
+ * paths, /usr/bin first (merged-usr distros) and /bin for the older layout.
+ *
+ * When a tool is not installed, `missing` names the capability it cannot
+ * measure, and the probe skips both the set and the get for it: a missing
+ * tool means the capability is *unmeasurable*, which the result reports as
+ * such and resolves by dropping the flag — the safe outcome, honestly
+ * labelled, and one that cannot take down the measurement of the others.
+ */
+interface ProbeTools {
+  readonly setXattr: readonly string[];
+  readonly getXattr: readonly string[];
+  readonly setAcl: readonly string[];
+  readonly getAcl: readonly string[];
+  readonly stripAcl: readonly string[];
+  /** Which capabilities could not be measured because their tools are absent. */
+  readonly missing: readonly string[];
+}
+
+function probeTools(): ProbeTools {
+  if (IS_MACOS) {
+    return {
+      setXattr: ["/usr/bin/xattr", "-w", XATTR_NAME, XATTR_VALUE],
+      getXattr: ["/usr/bin/xattr", "-l"],
+      setAcl: ["/bin/chmod", "+a", "everyone allow read"],
+      getAcl: ["/bin/ls", "-le"],
+      stripAcl: ["/bin/chmod", "-R", "-N"],
+      missing: [],
+    };
+  }
+  const missing: string[] = [];
+  const setfattr = resolveBin(["/usr/bin/setfattr", "/bin/setfattr"]);
+  const getfattr = resolveBin(["/usr/bin/getfattr", "/bin/getfattr"]);
+  const setfacl = resolveBin(["/usr/bin/setfacl", "/bin/setfacl"]);
+  const getfacl = resolveBin(["/usr/bin/getfacl", "/bin/getfacl"]);
+  if (setfattr === null || getfattr === null) missing.push("xattrs");
+  if (setfacl === null || getfacl === null) missing.push("acls");
+  return {
+    setXattr: [setfattr ?? "setfattr", "-n", XATTR_NAME, "-v", XATTR_VALUE],
+    getXattr: [getfattr ?? "getfattr"],
+    // `nobody` exists on every Linux box; an entry for it tests exactly what
+    // an `everyone` ACE tests on macOS.
+    setAcl: [setfacl ?? "setfacl", "-m", "u:nobody:rx"],
+    getAcl: [getfacl ?? "getfacl", "--omit-header"],
+    stripAcl: [setfacl ?? "setfacl", "-R", "-b"],
+    missing,
+  };
+}
 
 async function run(argv: readonly string[]): Promise<{ code: number | null; out: string }> {
   const proc = Bun.spawn(argv as string[], { stdout: "pipe", stderr: "pipe" });
@@ -53,17 +116,22 @@ export async function probeTarget(
 ): Promise<ProbeResult> {
   const staging = makeStaging("probe");
   const landedDir = join(targetRoot, PROBE_DIR);
+  const tools = probeTools();
 
   try {
     const file = stageFile(staging, "probe.txt", "syncy capability probe\n");
     // A mode with bits a permissive share is unlikely to reproduce by accident.
     await run(["/bin/chmod", "0640", file]);
 
-    await run(["/usr/bin/xattr", "-w", XATTR_NAME, XATTR_VALUE, file]);
-    // An ALLOW ace, deliberately. A "deny delete" ace tests the same capability
-    // but then blocks the probe's own cleanup, leaving undeletable files behind
-    // in the user's target.
-    await run(["/bin/chmod", "+a", "everyone allow read", file]);
+    // A failed *set* means the capability could not be exercised, which is
+    // reported as unmeasured rather than claimed as "not preserved": a
+    // read-only filesystem fails the set, not the preservation.
+    const xattrSet = tools.missing.includes("xattrs")
+      ? 1
+      : (await run([...tools.setXattr, file])).code;
+    const aclSet = tools.missing.includes("acls") ? 1 : (await run([...tools.setAcl, file])).code;
+    const xattrMeasured = xattrSet === 0;
+    const aclMeasured = aclSet === 0;
 
     const sync = await run([bin, "-a", "-A", "-X", staging + "/", landedDir + "/"]);
     if (sync.code !== 0) {
@@ -78,11 +146,26 @@ export async function probeTarget(
     }
 
     const landed = join(landedDir, "probe.txt");
-    const xattrList = await run(["/usr/bin/xattr", "-l", landed]);
-    const aclList = await run(["/bin/ls", "-le", landed]);
-
-    const xattrs = xattrList.out.includes(XATTR_NAME);
-    const acls = /\d+:\s/.test(aclList.out);
+    // The get is skipped, not run against a missing tool, for a capability
+    // that was not measured: Bun.spawn throws on a nonexistent binary, and a
+    // probe that fails on an absent getfattr must not lose the permissions
+    // answer it could have given.
+    let xattrs = false;
+    let acls = false;
+    if (xattrMeasured) {
+      const xattrList = await run([...tools.getXattr, landed]);
+      xattrs = xattrList.out.includes(XATTR_NAME);
+    }
+    if (aclMeasured) {
+      const aclList = await run([...tools.getAcl, landed]);
+      // macOS: `ls -le` prints ACL entries as numbered lines. Linux: getfacl
+      // prints named entries as `user:nobody:r-x`; the base three entries
+      // have an empty name, so the non-empty name is what distinguishes a
+      // real ACL.
+      acls = IS_MACOS
+        ? /\d+:\s/.test(aclList.out)
+        : /(?:user|group):[^:\s]+:[-rwx]+/.test(aclList.out);
+    }
     // Compared against what was sent, not against a fixed expectation: a share
     // that reports 0640 back is preserving permissions whatever else it does.
     const perms = modeOf(landed) === modeOf(file);
@@ -92,20 +175,28 @@ export async function probeTarget(
     if (!xattrs) flagsDrop.push("-X");
     if (!perms) flagsDrop.push("-p");
 
-    const missing = [
-      ...(acls ? [] : ["acls"]),
-      ...(xattrs ? [] : ["xattrs"]),
-      ...(perms ? [] : ["permissions"]),
-    ];
+    const missing: string[] = [];
+    const unmeasured: string[] = [];
+    // A failed *set* (or an absent tool) means the capability could not be
+    // exercised. That is reported as unmeasured, not folded into "does not
+    // preserve": a read-only filesystem fails the set, not the preservation.
+    if (tools.missing.includes("xattrs") || !xattrMeasured) unmeasured.push("xattrs");
+    if (tools.missing.includes("acls") || !aclMeasured) unmeasured.push("acls");
+    if (!unmeasured.includes("acls") && !acls) missing.push("acls");
+    if (!unmeasured.includes("xattrs") && !xattrs) missing.push("xattrs");
+    if (!perms) missing.push("permissions");
     return {
       xattrs,
       acls,
       perms,
       flagsDrop,
       detail:
-        missing.length === 0
+        missing.length === 0 && unmeasured.length === 0
           ? "acls, xattrs and permissions all survive"
-          : `does not preserve ${missing.join(", ")}`,
+          : [
+              ...(missing.length === 0 ? [] : [`does not preserve ${missing.join(", ")}`]),
+              ...(unmeasured.length === 0 ? [] : [`could not measure ${unmeasured.join(", ")}`]),
+            ].join(" · "),
     };
   } catch (e) {
     return {
@@ -133,9 +224,15 @@ export function removeProbeDir(dir: string): void {
     throw new Error(`refusing to remove a path that is not a probe directory: ${dir}`);
   }
   try {
-    Bun.spawnSync(["/bin/chmod", "-R", "-N", dir]);
+    // macOS: BSD `chmod -N` strips the ACL entries. Linux: setfacl -b does.
+    if (IS_MACOS) {
+      Bun.spawnSync(["/bin/chmod", "-R", "-N", dir]);
+    } else {
+      const setfacl = resolveBin(["/usr/bin/setfacl", "/bin/setfacl"]);
+      if (setfacl !== null) Bun.spawnSync([setfacl, "-R", "-b", dir]);
+    }
   } catch {
-    // No acls to strip, or chmod is unavailable; the removal below still tries.
+    // No acls to strip, or the tool is unavailable; the removal below still tries.
   }
   try {
     rmSync(dir, { recursive: true, force: true });

--- a/src/rsync.ts
+++ b/src/rsync.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { Config, Target } from "./config.ts";
+import { IS_MACOS } from "./platform.ts";
 
 /**
  * rsync invocation (DESIGN.md section 3).
@@ -13,15 +14,19 @@ import type { Config, Target } from "./config.ts";
 /**
  * Candidate locations for a real rsync, in preference order.
  *
- * Never resolved from PATH: on macOS `rsync` finds /usr/bin/rsync, which is
- * openrsync and rejects -A outright. Homebrew installs to /opt/homebrew on
- * Apple Silicon and /usr/local on Intel; MacPorts uses /opt/local.
+ * Never resolved from PATH. On macOS this never includes /usr/bin: there
+ * `rsync` is openrsync, which rejects -A outright. Homebrew installs to
+ * /opt/homebrew on Apple Silicon and /usr/local on Intel; MacPorts uses
+ * /opt/local.
+ *
+ * On Linux the distribution rsync at /usr/bin is the real thing, and that is
+ * where the package manager puts it, so it is the first candidate. checkBuild
+ * still refuses anything older than 3.x, and the openrsync test inside it is
+ * the backstop if someone installed the BSD variant on a Linux box.
  */
-export const RSYNC_CANDIDATES: readonly string[] = [
-  "/opt/homebrew/bin/rsync",
-  "/usr/local/bin/rsync",
-  "/opt/local/bin/rsync",
-];
+export const RSYNC_CANDIDATES: readonly string[] = IS_MACOS
+  ? ["/opt/homebrew/bin/rsync", "/usr/local/bin/rsync", "/opt/local/bin/rsync"]
+  : ["/usr/bin/rsync", "/usr/local/bin/rsync"];
 
 /** `SYNCY_RSYNC` overrides everything, for an rsync installed elsewhere. */
 export function resolveRsync(env: NodeJS.ProcessEnv = process.env): string {

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -36,14 +36,31 @@ export type Reachability = SentinelStatus | "unreachable";
  * mounted at the path and compares that with what was recorded — nothing is
  * written to the destination. `sentinel` reads a file syncy placed at the
  * target root, which additionally catches the directory being deleted and
- * recreated. Identity wins when both are present.
+ * recreated.
+ *
+ * A volume uuid stands on its own: it names the filesystem, and no other
+ * filesystem can answer to it. A *mount source* does not, and `identityKind`
+ * is what separates the two. `//nas/media` is a real remote name, but the
+ * other thing that lands in that field is a local device path, which
+ * `identify` falls back to whenever the kernel publishes no uuid — and
+ * `/dev/sdb1` is a slot in this boot's enumeration order. Unplug the backup
+ * disk, plug a different one into the same port, and it answers to the same
+ * path. So where the identity is a mount source the sentinel is checked too,
+ * and it is the sentinel's answer that is returned: it is the one that
+ * survives the disk being swapped.
+ *
+ * Targets recorded before `identity_kind` existed have no kind, and are
+ * treated as mount-source for the same reason absence of provenance is
+ * treated as no evidence everywhere else here.
  */
 export async function targetReachability(target: Target): Promise<Reachability> {
   if (target.identity !== undefined && target.identity !== "") {
     const v = await checkVolume(target.path, target.identity);
     if (v !== "ok") return v === "unreachable" ? "unreachable" : "mismatch";
     // The volume is right; the directory still has to exist on it.
-    return existsSync(target.path) ? "ok" : "unreachable";
+    if (!existsSync(target.path)) return "unreachable";
+    if (target.identityKind === "volume-uuid" || target.sentinel === undefined) return "ok";
+    return checkSentinel(target.path, target.sentinel);
   }
   if (!existsSync(target.path)) return "unreachable";
   if (target.sentinel === undefined) return "missing";

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -38,20 +38,28 @@ export type Reachability = SentinelStatus | "unreachable";
  * target root, which additionally catches the directory being deleted and
  * recreated.
  *
- * A volume uuid stands on its own: it names the filesystem, and no other
- * filesystem can answer to it. A *mount source* does not, and `identityKind`
- * is what separates the two. `//nas/media` is a real remote name, but the
- * other thing that lands in that field is a local device path, which
- * `identify` falls back to whenever the kernel publishes no uuid — and
- * `/dev/sdb1` is a slot in this boot's enumeration order. Unplug the backup
- * disk, plug a different one into the same port, and it answers to the same
- * path. So where the identity is a mount source the sentinel is checked too,
- * and it is the sentinel's answer that is returned: it is the one that
- * survives the disk being swapped.
+ * Not every recorded identity is proof, and `identityIsProof` is where that
+ * is decided. A volume uuid names the filesystem and nothing else can answer
+ * to it. A network mount source — `//nas/media`, `archive:/exports` — names a
+ * host and an export, which is equally a name for the thing itself. A local
+ * device path is neither: `identify` falls back to one when no uuid is
+ * published, and `/dev/sdb1` is a slot in this boot's enumeration order.
+ * Unplug the backup disk, plug a different one into the same port, and it
+ * answers to the same path.
  *
- * Targets recorded before `identity_kind` existed have no kind, and are
- * treated as mount-source for the same reason absence of provenance is
- * treated as no evidence everywhere else here.
+ * So a device-path identity is checked — it still catches the volume being
+ * unmounted — and then handed to the sentinel, whose answer is returned: the
+ * sentinel is the thing that survives the disk being swapped, and where one
+ * exists it should be what decides.
+ *
+ * With no sentinel to hand it to, the device path is accepted. That is the
+ * weakest branch here and it is deliberate: refusing instead makes syncy
+ * unusable on a machine that publishes no uuid — a container, a system
+ * without udev, or a root filesystem the initramfs named `/dev/root` — and a
+ * tool that will not run is not safer than one that runs with a proof it has
+ * labelled as weak. `resolveTarget` says so when the target is added, and
+ * `syncy sentinel` is how someone upgrades it. What this must never do is
+ * silently treat it as equal to a uuid, which is what it used to do.
  */
 export async function targetReachability(target: Target): Promise<Reachability> {
   if (target.identity !== undefined && target.identity !== "") {
@@ -59,12 +67,32 @@ export async function targetReachability(target: Target): Promise<Reachability> 
     if (v !== "ok") return v === "unreachable" ? "unreachable" : "mismatch";
     // The volume is right; the directory still has to exist on it.
     if (!existsSync(target.path)) return "unreachable";
-    if (target.identityKind === "volume-uuid" || target.sentinel === undefined) return "ok";
+    if (identityIsProof(target) || target.sentinel === undefined) return "ok";
     return checkSentinel(target.path, target.sentinel);
   }
   if (!existsSync(target.path)) return "unreachable";
   if (target.sentinel === undefined) return "missing";
   return checkSentinel(target.path, target.sentinel);
+}
+
+/**
+ * Whether a target's recorded identity names the volume, or merely where it
+ * was plugged in this time.
+ *
+ * A device path is the one identity `identify` can return that a different
+ * disk will answer to tomorrow — /dev/diskN on macOS, /dev/sdb1 on Linux —
+ * and it is what the mount source falls back to when the kernel publishes no
+ * uuid. Everything else in that field is a name for the volume: a uuid, or a
+ * network share's host and export.
+ *
+ * The shape is the test rather than a fourth `identityKind`, because it needs
+ * no migration and cannot disagree with the value it is describing: a config
+ * written before this existed gets the same answer as one written after.
+ */
+export function identityIsProof(target: Target): boolean {
+  const id = target.identity ?? "";
+  if (id === "") return false;
+  return !id.startsWith("/dev/");
 }
 
 export async function allReachability(config: Config): Promise<Map<string, Reachability>> {

--- a/src/tui/Setup.tsx
+++ b/src/tui/Setup.tsx
@@ -9,8 +9,7 @@ import { bytes } from "../format.ts";
 import { type MountEntry, modifyWindowFor } from "../fstype.ts";
 import { configFile } from "../paths.ts";
 import { probeTarget } from "../probe.ts";
-import { listUnits, targetReachability } from "../scan.ts";
-import { writeSentinel } from "../sentinel.ts";
+import { identityIsProof, listUnits, targetReachability } from "../scan.ts";
 import { describeVolume, identify, type MountedVolume, mountedVolumes } from "../volume.ts";
 import { padEnd, truncate, truncatePath } from "../width.ts";
 import { Rule, Screen } from "./Screen.tsx";
@@ -132,55 +131,25 @@ export async function resolveTarget(
   onProgress?.(`probing ${name} for acl and xattr support…`);
   const probe = await probeTarget(abs);
 
-  /**
-   * A sentinel, when the identity is not a volume uuid.
-   *
-   * A uuid names the filesystem and nothing else can answer to it, so it is
-   * proof on its own. A mount source is not: `//nas/media` is a real remote
-   * name, but the same field also holds the local device path `identify`
-   * falls back to when no uuid is published — which on Linux is the common
-   * case — and `/dev/sdb1` is a slot in this boot's enumeration order, not a
-   * disk. `targetReachability` checks the sentinel for exactly these targets,
-   * so this is where the file it reads has to come from.
-   *
-   * After the probe, never before: identify() decides whether anything is
-   * written here at all, and the probe is the write that proves the target
-   * accepts one.
-   */
-  let sentinel: string | undefined;
-  if (found.kind !== "volume-uuid") {
-    onProgress?.(`writing the sentinel at ${name}…`);
-    try {
-      sentinel = await writeSentinel(abs);
-    } catch {
-      // The target is still usable, with the weaker proof. Said out loud in
-      // `detail` rather than silently downgraded.
-      sentinel = undefined;
-    }
-  }
-
   const target: Target = {
     name,
     path: abs,
     required: true,
     identity: found.id,
     identityKind: found.kind,
-    ...(sentinel !== undefined ? { sentinel } : {}),
     fstype,
     modifyWindow: modifyWindowFor(fstype),
     flagsDrop: probe.flagsDrop,
   };
-  const proof =
-    found.kind === "volume-uuid"
-      ? `${found.kind} ${found.id}`
-      : sentinel !== undefined
-        ? `${found.kind} ${found.id} + sentinel`
-        : `${found.kind} ${found.id} · no sentinel could be written`;
-  return {
-    ok: true,
-    target,
-    detail: `${name}: ${fstype} · ${proof} · ${probe.detail}`,
-  };
+  // A device path is recorded like any other identity, and said out loud as
+  // the weaker thing it is: `targetReachability` will not accept it as proof
+  // on its own, so the person adding the target should hear that here rather
+  // than discover it as an "unverified" row later.
+  const detail = identityIsProof(target)
+    ? `${name}: ${fstype} · ${found.kind} ${found.id} · ${probe.detail}`
+    : `${name}: ${fstype} · device path ${found.id}, not a volume name — ` +
+      `run \`syncy sentinel ${abs}\` to prove it by a file instead · ${probe.detail}`;
+  return { ok: true, target, detail };
 }
 
 export function Setup({

--- a/src/tui/Setup.tsx
+++ b/src/tui/Setup.tsx
@@ -10,6 +10,7 @@ import { type MountEntry, modifyWindowFor } from "../fstype.ts";
 import { configFile } from "../paths.ts";
 import { probeTarget } from "../probe.ts";
 import { listUnits, targetReachability } from "../scan.ts";
+import { writeSentinel } from "../sentinel.ts";
 import { describeVolume, identify, type MountedVolume, mountedVolumes } from "../volume.ts";
 import { padEnd, truncate, truncatePath } from "../width.ts";
 import { Rule, Screen } from "./Screen.tsx";
@@ -130,20 +131,55 @@ export async function resolveTarget(
   const fstype = found.fstype;
   onProgress?.(`probing ${name} for acl and xattr support…`);
   const probe = await probeTarget(abs);
+
+  /**
+   * A sentinel, when the identity is not a volume uuid.
+   *
+   * A uuid names the filesystem and nothing else can answer to it, so it is
+   * proof on its own. A mount source is not: `//nas/media` is a real remote
+   * name, but the same field also holds the local device path `identify`
+   * falls back to when no uuid is published — which on Linux is the common
+   * case — and `/dev/sdb1` is a slot in this boot's enumeration order, not a
+   * disk. `targetReachability` checks the sentinel for exactly these targets,
+   * so this is where the file it reads has to come from.
+   *
+   * After the probe, never before: identify() decides whether anything is
+   * written here at all, and the probe is the write that proves the target
+   * accepts one.
+   */
+  let sentinel: string | undefined;
+  if (found.kind !== "volume-uuid") {
+    onProgress?.(`writing the sentinel at ${name}…`);
+    try {
+      sentinel = await writeSentinel(abs);
+    } catch {
+      // The target is still usable, with the weaker proof. Said out loud in
+      // `detail` rather than silently downgraded.
+      sentinel = undefined;
+    }
+  }
+
   const target: Target = {
     name,
     path: abs,
     required: true,
     identity: found.id,
     identityKind: found.kind,
+    ...(sentinel !== undefined ? { sentinel } : {}),
     fstype,
     modifyWindow: modifyWindowFor(fstype),
     flagsDrop: probe.flagsDrop,
   };
+  const proof =
+    found.kind === "volume-uuid"
+      ? `${found.kind} ${found.id}`
+      : sentinel !== undefined
+        ? `${found.kind} ${found.id} + sentinel`
+        : `${found.kind} ${found.id} · no sentinel could be written`;
   return {
     ok: true,
     target,
-    detail: `${name}: ${fstype} · ${found.kind} ${found.id} · ${probe.detail}`,
+    detail: `${name}: ${fstype} · ${proof} · ${probe.detail}`,
   };
 }
 

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1,5 +1,14 @@
-import { statfsSync } from "node:fs";
-import { fstypeFor, type MountEntry, mountEntryFor, parseMount } from "./fstype.ts";
+import { readFileSync, statfsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+  fstypeFor,
+  type MountEntry,
+  mountEntryFor,
+  PSEUDO_FSTYPES,
+  parseMount,
+  parseProcMounts,
+} from "./fstype.ts";
+import { IS_LINUX, IS_MACOS } from "./platform.ts";
 
 /**
  * Identifying a destination without writing anything to it.
@@ -15,7 +24,7 @@ import { fstypeFor, type MountEntry, mountEntryFor, parseMount } from "./fstype.
  */
 
 /** Filesystems with no block device, identified by their mount source instead. */
-const NETWORK_FS = ["smbfs", "nfs", "afpfs", "webdav", "ftp", "cifs"];
+const NETWORK_FS = ["smbfs", "nfs", "afpfs", "webdav", "ftp", "cifs", "sshfs", "9p"];
 
 export interface VolumeIdentity {
   /** A stable string for the volume: a volume uuid, or a mount source. */
@@ -57,10 +66,11 @@ export function forgetVolumeUuids(): void {
   uuidCache.clear();
 }
 
-/** Volume UUID from diskutil, for filesystems that have one. */
-export async function volumeUuid(mountPoint: string): Promise<string | null> {
+/** Volume UUID from diskutil (macOS) or sysfs (Linux), for filesystems that have one. */
+async function volumeUuid(entry: MountEntry): Promise<string | null> {
+  if (IS_LINUX) return volumeUuidLinux(entry);
   try {
-    const proc = Bun.spawn(["/usr/sbin/diskutil", "info", mountPoint], {
+    const proc = Bun.spawn(["/usr/sbin/diskutil", "info", entry.mountPoint], {
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -71,6 +81,63 @@ export async function volumeUuid(mountPoint: string): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+/**
+ * Read a sysfs file, or null when it does not exist or is empty.
+ *
+ * Sysfs is how Linux publishes volume facts — a UUID per filesystem, a
+ * `removable` bit per block device — as plain files, in the spirit this
+ * project keeps its own record in. The reader is injectable so the decisions
+ * built on top of it can be tested without a matching piece of hardware.
+ */
+export function readSysText(path: string): string | null {
+  try {
+    const v = readFileSync(path, "utf8").trim();
+    return v === "" ? null : v;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Volume UUID on Linux, from the kernel's own sysfs — the equivalent of what
+ * diskutil answers on macOS.
+ *
+ * Two routes, because containers and namespaced systems filter `/sys/block`
+ * down to whatever the process sees: the device name first (`/sys/block/sdb1`
+ * holds `uuid` for ext4/xfs/btrfs and `partuuid` for FAT-family), then the
+ * devnum from `stat`, which resolves through `/sys/dev/block` on systems where
+ * the name-based path does not exist.
+ *
+ * Null when the kernel publishes no UUID for the device (LVM without one, some
+ * loop images). The caller falls back to the device path as a mount-source
+ * identity, which still separates one volume from another.
+ */
+export function volumeUuidLinux(
+  entry: MountEntry,
+  readText: (path: string) => string | null = readSysText,
+): string | null {
+  const candidates: string[] = [];
+  const name = entry.device.startsWith("/dev/") ? entry.device.slice("/dev/".length) : null;
+  if (name !== null && name !== "" && !name.includes("/")) {
+    candidates.push(join("/sys/block", name, "uuid"));
+    candidates.push(join("/sys/block", name, "partuuid"));
+  }
+  try {
+    const dev = statSync(entry.mountPoint).dev;
+    const maj = (dev >> 8) & 0xfff;
+    const min = (dev & 0xff) | ((dev >> 12) & 0xfff00);
+    candidates.push(join("/sys/dev/block", `${maj}:${min}`, "uuid"));
+    candidates.push(join("/sys/dev/block", `${maj}:${min}`, "partuuid"));
+  } catch {
+    // The mount point is gone or unreadable; the name-based route above stands.
+  }
+  for (const c of candidates) {
+    const v = readText(c);
+    if (v !== null) return v;
+  }
+  return null;
 }
 
 /**
@@ -99,16 +166,27 @@ export function forgetMountTable(): void {
 async function mountTable(): Promise<MountEntry[]> {
   const now = Date.now();
   if (mountCache !== null && now - mountCache.at < MOUNT_TABLE_TTL_MS) return mountCache.entries;
-  try {
-    const proc = Bun.spawn(["/sbin/mount"], { stdout: "pipe", stderr: "pipe" });
-    const out = await new Response(proc.stdout).text();
-    await proc.exited;
-    const entries = parseMount(out);
-    mountCache = { at: Date.now(), entries };
-    return entries;
-  } catch {
-    return [];
+  let entries: MountEntry[] = [];
+  if (IS_LINUX) {
+    // /proc/mounts is the kernel's own table, already in memory: no spawn, and
+    // no stall enumerating a dead share the way `mount` can.
+    try {
+      entries = parseProcMounts(readFileSync("/proc/mounts", "utf8"));
+    } catch {
+      entries = [];
+    }
+  } else {
+    try {
+      const proc = Bun.spawn(["/sbin/mount"], { stdout: "pipe", stderr: "pipe" });
+      const out = await new Response(proc.stdout).text();
+      await proc.exited;
+      entries = parseMount(out);
+    } catch {
+      entries = [];
+    }
   }
+  mountCache = { at: Date.now(), entries };
+  return entries;
 }
 
 /**
@@ -140,7 +218,7 @@ export async function identify(
   const cacheKey = `${entry.device}\u0000${entry.mountPoint}`;
   const uuid = uuidCache.has(cacheKey)
     ? uuidCache.get(cacheKey)!
-    : await volumeUuid(entry.mountPoint).then((u) => {
+    : await volumeUuid(entry).then((u) => {
         uuidCache.set(cacheKey, u);
         return u;
       });
@@ -204,7 +282,35 @@ export interface MountedVolume {
  */
 export function classify(entry: MountEntry): VolumeKind {
   if (!entry.local) return isNetwork(entry.fstype) ? "network" : "unknown";
-  return "internal";
+  if (IS_MACOS) return "internal";
+  return classifyLinuxDevice(entry.device);
+}
+
+/**
+ * Local disks on Linux, from the device node, then /sys.
+ *
+ * Loop devices back mounted disk images rather than hardware. "external" and
+ * "internal" are claims about hardware, and the vocabulary no longer has a
+ * word for "image" (it was removed as unreachable on macOS — DESIGN.md §10),
+ * so a loop mount is the one local device class that is honestly unknown.
+ */
+export function classifyLinuxDevice(device: string): VolumeKind {
+  if (device.startsWith("/dev/loop")) return "unknown";
+  if (!device.startsWith("/dev/")) return "unknown";
+  const name = device.slice("/dev/".length).split("/")[0] ?? "";
+  return isRemovableBlock(name) ? "external" : "internal";
+}
+
+/**
+ * `/sys/block/<name>/removable` is `1` for USB and similar hot-pluggable
+ * disks. The read is trimmed: sysfs files end in a newline, and a reader that
+ * returns surrounding whitespace must not read as "not removable".
+ */
+export function isRemovableBlock(
+  name: string,
+  readText: (path: string) => string | null = readSysText,
+): boolean {
+  return (readText(join("/sys/block", name, "removable")) ?? "").trim() === "1";
 }
 
 /** A short label for a volume, for a list someone is picking from. */
@@ -215,7 +321,8 @@ export function describeVolume(v: MountedVolume): string {
     case "external":
       return `external disk · ${v.fstype}`;
     case "internal":
-      return `this mac · ${v.fstype}`;
+      // The boot volume, in the words the platform uses for it.
+      return `${IS_MACOS ? "this mac" : "this computer"} · ${v.fstype}`;
     default:
       return v.fstype;
   }
@@ -230,6 +337,9 @@ export function describeVolume(v: MountedVolume): string {
 const locationCache = new Map<string, boolean>();
 
 async function isExternal(mountPoint: string, device: string): Promise<boolean> {
+  // On Linux classify() has already asked /sys the same question, so this is
+  // the no-op branch rather than a second, slower measurement.
+  if (IS_LINUX) return false;
   const hit = locationCache.get(device);
   if (hit !== undefined) return hit;
   try {
@@ -259,17 +369,38 @@ export async function mountedVolumes(): Promise<MountedVolume[]> {
   const entries = await mountTable();
   const out: MountedVolume[] = [];
   for (const e of entries) {
-    // Only volumes someone could plausibly point a destination at. Hidden
-    // mount points are excluded: Time Machine keeps its snapshots under
-    // /Volumes/.timemachine/… with names like a UUID inside a hostname, which
-    // is noise in a list meant to be scanned by eye.
-    if (e.mountPoint !== "/" && !e.mountPoint.startsWith("/Volumes/")) continue;
+    // Only volumes someone could plausibly point a destination at.
+    //
+    // macOS: that means the boot volume and /Volumes/* — Time Machine keeps
+    // its snapshots under /Volumes/.timemachine/… with names like a UUID
+    // inside a hostname, which the hidden-segment check below removes.
+    //
+    // Linux: the mount table lists the kernel's own filesystems too, and
+    // /proc/mounts on a real box is dozens of lines — so pseudo-filesystems
+    // are filtered out here, and anything still unclassifiable (a FUSE mount
+    // with no block device, zfs) is dropped rather than offered as a
+    // destination of unknown character. Typed paths are not affected: this
+    // list only annotates completions.
+    if (e.mountPoint === "") continue;
+    if (IS_MACOS) {
+      if (e.mountPoint !== "/" && !e.mountPoint.startsWith("/Volumes/")) continue;
+    } else {
+      if (PSEUDO_FSTYPES.has(e.fstype.toLowerCase())) continue;
+    }
     if (e.mountPoint.split("/").some((seg) => seg.startsWith("."))) continue;
     let kind = classify(e);
+    if (IS_LINUX && kind === "unknown") continue;
     if (kind === "internal" && (await isExternal(e.mountPoint, e.device))) kind = "external";
     out.push({
       mountPoint: e.mountPoint,
-      name: e.mountPoint === "/" ? "Macintosh HD" : e.mountPoint.slice("/Volumes/".length),
+      name:
+        e.mountPoint === "/"
+          ? IS_MACOS
+            ? "Macintosh HD"
+            : "root"
+          : IS_MACOS
+            ? e.mountPoint.slice("/Volumes/".length)
+            : e.mountPoint,
       kind,
       fstype: e.fstype,
       device: e.device,

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statfsSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, realpathSync, statfsSync } from "node:fs";
 import { join } from "node:path";
 import {
   fstypeFor,
@@ -84,58 +84,104 @@ async function volumeUuid(entry: MountEntry): Promise<string | null> {
 }
 
 /**
- * Read a sysfs file, or null when it does not exist or is empty.
+ * The three filesystem questions the Linux volume code asks the kernel.
  *
- * Sysfs is how Linux publishes volume facts — a UUID per filesystem, a
- * `removable` bit per block device — as plain files, in the spirit this
- * project keeps its own record in. The reader is injectable so the decisions
- * built on top of it can be tested without a matching piece of hardware.
+ * Injectable as one object so the decisions built on top can be tested
+ * without a matching piece of hardware — and so a test cannot accidentally
+ * pass by reading the real machine.
  */
-export function readSysText(path: string): string | null {
-  try {
-    const v = readFileSync(path, "utf8").trim();
-    return v === "" ? null : v;
-  } catch {
-    return null;
-  }
+export interface LinuxVolumeIo {
+  /** A sysfs file's contents, trimmed, or null when absent or empty. */
+  readonly readText: (path: string) => string | null;
+  /** A directory's entries, or empty when it does not exist. */
+  readonly list: (dir: string) => readonly string[];
+  /** A path with its symlinks resolved, or null when it does not resolve. */
+  readonly realpath: (path: string) => string | null;
 }
 
+export const realVolumeIo: LinuxVolumeIo = {
+  readText: (path) => {
+    try {
+      const v = readFileSync(path, "utf8").trim();
+      return v === "" ? null : v;
+    } catch {
+      return null;
+    }
+  },
+  list: (dir) => {
+    try {
+      return readdirSync(dir);
+    } catch {
+      return [];
+    }
+  },
+  realpath: (path) => {
+    try {
+      return realpathSync(path);
+    } catch {
+      return null;
+    }
+  },
+};
+
 /**
- * Volume UUID on Linux, from the kernel's own sysfs — the equivalent of what
- * diskutil answers on macOS.
+ * udev's by-uuid directories, in the order they answer.
  *
- * Two routes, because containers and namespaced systems filter `/sys/block`
- * down to whatever the process sees: the device name first (`/sys/block/sdb1`
- * holds `uuid` for ext4/xfs/btrfs and `partuuid` for FAT-family), then the
- * devnum from `stat`, which resolves through `/sys/dev/block` on systems where
- * the name-based path does not exist.
+ * `by-uuid` is the filesystem's own uuid, which is what `diskutil info`
+ * reports on macOS and what survives a reformat-free replug on any port.
+ * `by-partuuid` is the partition table's, one level weaker but still a
+ * property of the disk rather than of this boot — the FAT-family fallback,
+ * since a vfat volume's "uuid" is a four-byte serial that udev exposes here.
+ */
+const BY_ID_DIRS = ["/dev/disk/by-uuid", "/dev/disk/by-partuuid"] as const;
+
+/**
+ * Volume UUID on Linux — the equivalent of what diskutil answers on macOS.
  *
- * Null when the kernel publishes no UUID for the device (LVM without one, some
- * loop images). The caller falls back to the device path as a mount-source
- * identity, which still separates one volume from another.
+ * Not from sysfs. A *filesystem* uuid lives in the superblock, not in
+ * `/sys`: the kernel never publishes one for a block device, and the paths
+ * this used to read — `/sys/block/<name>/uuid`, `/sys/block/<name>/partuuid`
+ * — do not exist for the mounts syncy is pointed at. `/sys/block` holds
+ * whole disks only (a partition is a subdirectory of its disk), and neither
+ * a `uuid` nor a `partuuid` attribute is published there for either. Every
+ * Linux volume therefore fell through to the device path, and `/dev/sdb1` is
+ * a slot in this boot's enumeration order, not a name for a disk.
+ *
+ * udev publishes the real answer as symlinks under /dev/disk, so the lookup
+ * is: resolve the mount's device to its canonical node, then find the
+ * by-uuid (then by-partuuid) entry that resolves to the same node.
+ *
+ * sysfs is still consulted last, for the device classes that do publish a
+ * uuid of their own — an NVMe namespace, a device-mapper volume — which
+ * covers a whole-disk mount on a system running without udev. That read is
+ * `/sys/class/block`, which holds partitions as well as disks; `/sys/block`
+ * does not.
+ *
+ * Null when nothing stable is published (LVM without a uuid, a loop image,
+ * a container with no /dev/disk). The caller must then treat the device path
+ * as the weak identity it is — see `targetReachability`.
  */
 export function volumeUuidLinux(
   entry: MountEntry,
-  readText: (path: string) => string | null = readSysText,
+  io: LinuxVolumeIo = realVolumeIo,
 ): string | null {
-  const candidates: string[] = [];
-  const name = entry.device.startsWith("/dev/") ? entry.device.slice("/dev/".length) : null;
-  if (name !== null && name !== "" && !name.includes("/")) {
-    candidates.push(join("/sys/block", name, "uuid"));
-    candidates.push(join("/sys/block", name, "partuuid"));
+  if (!entry.device.startsWith("/dev/")) return null;
+  const node = io.realpath(entry.device) ?? entry.device;
+
+  for (const dir of BY_ID_DIRS) {
+    for (const name of io.list(dir)) {
+      if (io.realpath(join(dir, name)) === node) return name;
+    }
   }
-  try {
-    const dev = statSync(entry.mountPoint).dev;
-    const maj = (dev >> 8) & 0xfff;
-    const min = (dev & 0xff) | ((dev >> 12) & 0xfff00);
-    candidates.push(join("/sys/dev/block", `${maj}:${min}`, "uuid"));
-    candidates.push(join("/sys/dev/block", `${maj}:${min}`, "partuuid"));
-  } catch {
-    // The mount point is gone or unreadable; the name-based route above stands.
-  }
-  for (const c of candidates) {
-    const v = readText(c);
-    if (v !== null) return v;
+
+  const leaf = node.slice("/dev/".length);
+  if (leaf !== "" && !leaf.includes("/")) {
+    const own = io.readText(join("/sys/class/block", leaf, "uuid"));
+    if (own !== null) return own;
+    // Device-mapper keeps its uuid one level down, and prefixes it with the
+    // subsystem that made the volume (LVM-…, CRYPT-LUKS2-…).
+    const dm = io.readText(join("/sys/class/block", leaf, "dm", "uuid"));
+    if (dm !== null) return dm;
   }
   return null;
 }
@@ -294,23 +340,43 @@ export function classify(entry: MountEntry): VolumeKind {
  * word for "image" (it was removed as unreachable on macOS — DESIGN.md §10),
  * so a loop mount is the one local device class that is honestly unknown.
  */
-export function classifyLinuxDevice(device: string): VolumeKind {
+export function classifyLinuxDevice(device: string, io: LinuxVolumeIo = realVolumeIo): VolumeKind {
   if (device.startsWith("/dev/loop")) return "unknown";
   if (!device.startsWith("/dev/")) return "unknown";
-  const name = device.slice("/dev/".length).split("/")[0] ?? "";
-  return isRemovableBlock(name) ? "external" : "internal";
+  return isRemovableDevice(device, io) ? "external" : "internal";
 }
 
 /**
- * `/sys/block/<name>/removable` is `1` for USB and similar hot-pluggable
- * disks. The read is trimmed: sysfs files end in a newline, and a reader that
+ * Whether a device node sits on a hot-pluggable disk: `removable` is `1` for
+ * USB and similar.
+ *
+ * The attribute is published per *disk*, never per partition, and mounts name
+ * partitions — so `/sys/block/sdb1/removable`, which this used to read, does
+ * not exist on any machine and every external disk classified as internal.
+ * Two corrections: `/sys/class/block` holds partitions as well as disks
+ * (`/sys/block` holds only disks), and a partition's own directory has no
+ * `removable`, so `..` from it — resolved through the symlink by the kernel —
+ * is its disk.
+ *
+ * The device is realpath'd first, so /dev/mapper/vg-lv is asked about as the
+ * dm-N it actually is rather than as a directory name.
+ *
+ * The read is trimmed: sysfs files end in a newline, and a reader that
  * returns surrounding whitespace must not read as "not removable".
  */
-export function isRemovableBlock(
-  name: string,
-  readText: (path: string) => string | null = readSysText,
-): boolean {
-  return (readText(join("/sys/block", name, "removable")) ?? "").trim() === "1";
+export function isRemovableDevice(device: string, io: LinuxVolumeIo = realVolumeIo): boolean {
+  const node = io.realpath(device) ?? device;
+  if (!node.startsWith("/dev/")) return false;
+  const name = node.slice("/dev/".length);
+  if (name === "" || name.includes("/")) return false;
+  const base = join("/sys/class/block", name);
+  const own = io.readText(join(base, "removable"));
+  // Concatenated, not `join`ed: join normalises `..` away lexically, which
+  // would ask about /sys/class/block itself. The `..` has to survive into the
+  // path so the *kernel* resolves it — symlink first, then the parent — which
+  // is what turns a partition's directory into its disk's.
+  const value = own ?? io.readText(`${base}/../removable`);
+  return (value ?? "").trim() === "1";
 }
 
 /** A short label for a volume, for a list someone is picking from. */

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, realpathSync, statfsSync } from "node:fs";
+import { readdirSync, readFileSync, realpathSync, statfsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import {
   fstypeFor,
@@ -97,6 +97,8 @@ export interface LinuxVolumeIo {
   readonly list: (dir: string) => readonly string[];
   /** A path with its symlinks resolved, or null when it does not resolve. */
   readonly realpath: (path: string) => string | null;
+  /** The device number of whatever is mounted at a path, or null. */
+  readonly deviceNumber: (path: string) => number | null;
 }
 
 export const realVolumeIo: LinuxVolumeIo = {
@@ -122,7 +124,43 @@ export const realVolumeIo: LinuxVolumeIo = {
       return null;
     }
   },
+  deviceNumber: (path) => {
+    try {
+      return statSync(path).dev;
+    } catch {
+      return null;
+    }
+  },
 };
+
+/**
+ * The kernel's own name for whatever backs a mount, as an absolute node.
+ *
+ * `/proc/mounts` does not always print one that exists. A root filesystem
+ * brought up by an initramfs is listed as `/dev/root` on most cloud images —
+ * a name with no node behind it, and the CI runners this is tested on are
+ * exactly that — while being the single most likely mount for someone to
+ * point syncy at. The mount's *device number* is real regardless, and
+ * `/sys/dev/block/<major>:<minor>` is a symlink into the device tree whose
+ * last segment is the name the kernel uses for it: `sda1`.
+ *
+ * The major/minor split is glibc's, which covers every block device. A wrong
+ * answer only means the sysfs path does not exist, and the caller falls
+ * through exactly as it would for any device it cannot resolve.
+ */
+function canonicalNode(entry: MountEntry, io: LinuxVolumeIo): string | null {
+  const direct = io.realpath(entry.device);
+  if (direct?.startsWith("/dev/")) return direct;
+
+  const dev = io.deviceNumber(entry.mountPoint);
+  if (dev === null) return null;
+  const major = (dev >> 8) & 0xfff;
+  const minor = (dev & 0xff) | ((dev >> 12) & 0xfff00);
+  const resolved = io.realpath(join("/sys/dev/block", `${major}:${minor}`));
+  if (resolved === null) return null;
+  const name = resolved.slice(resolved.lastIndexOf("/") + 1);
+  return name === "" ? null : join("/dev", name);
+}
 
 /**
  * udev's by-uuid directories, in the order they answer.
@@ -166,7 +204,8 @@ export function volumeUuidLinux(
   io: LinuxVolumeIo = realVolumeIo,
 ): string | null {
   if (!entry.device.startsWith("/dev/")) return null;
-  const node = io.realpath(entry.device) ?? entry.device;
+  const node = canonicalNode(entry, io);
+  if (node === null) return null;
 
   for (const dir of BY_ID_DIRS) {
     for (const name of io.list(dir)) {

--- a/test/clipboard.test.ts
+++ b/test/clipboard.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { copyToClipboard } from "../src/clipboard.ts";
+
+/**
+ * Copying is a convenience with a platform-dependent toolchain behind it, so
+ * the contract under test is the shape of the answer: a status string is
+ * always returned, and the absence of a clipboard tool is reported rather
+ * than thrown. On a machine with pbcopy or wl-clipboard the copy succeeds;
+ * on a headless one it does not. Both must keep the program running.
+ */
+describe("clipboard", () => {
+  test("always answers with a status, never throws", async () => {
+    const message = await copyToClipboard("a plan that fits in a terminal\n");
+    expect(typeof message).toBe("string");
+    expect(message.length).toBeGreaterThan(0);
+  });
+
+  test("a short plan is not refused by the transport", async () => {
+    const message = await copyToClipboard("");
+    expect(typeof message).toBe("string");
+  });
+});

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { type Config, parseConfig, type Target } from "../src/config.ts";
 import { fingerprint } from "../src/fingerprint.ts";
 import { checkBuild, DEFAULT_RSYNC } from "../src/rsync.ts";
-import { allReachability, checkUnit, listUnits, targetReachability } from "../src/scan.ts";
+import {
+  allReachability,
+  checkUnit,
+  identityIsProof,
+  listUnits,
+  targetReachability,
+} from "../src/scan.ts";
 import { SENTINEL_NAME, writeSentinel } from "../src/sentinel.ts";
 import { EMPTY_STATE, type State, upsertScan } from "../src/state.ts";
 import { evaluateUnit } from "../src/status.ts";
@@ -117,58 +123,83 @@ describeRsync("units and reachability", () => {
 });
 
 /**
- * What a recorded identity is worth depends on what kind of identity it is.
+ * What a recorded identity is worth depends on what it is a name for.
  *
- * The identity of the fixture path is whatever this machine actually answers
- * for it, so these run the real `checkVolume` against the real mount table on
- * either platform; only the recorded `identityKind` varies, which is the
- * thing under test.
+ * The decision itself is a pure predicate, so it is tested as one — every
+ * shape that reaches the field, on either platform, without needing the disk
+ * that produced it. The wiring below then checks that the fixture's own
+ * identity, whatever this machine answers, still resolves.
  */
-describeRsync("a mount-source identity does not outrank the sentinel", () => {
-  const withIdentity = async (
-    kind: "volume-uuid" | "mount-source" | undefined,
-    sentinel: string | undefined,
-  ): Promise<Target> => {
+describe("which identities are proof on their own", () => {
+  const withIdentity = (identity: string): Target => ({ ...target("ext"), identity }) as Target;
+
+  test("a volume uuid and a network share name are both names for the volume", () => {
+    // macOS uuid, Linux uuid, an SMB share, an NFS export, a user@host share.
+    for (const id of [
+      "1A2B3C4D-5E6F-7A8B-9C0D-1E2F3A4B5C6D",
+      "8f3b-ARCHIVE",
+      "//nas.local/media",
+      "//backup@nas.local/media",
+      "archive.example:/exports/videos",
+    ]) {
+      expect(identityIsProof(withIdentity(id)), id).toBe(true);
+    }
+  });
+
+  test("a device path is not: a different disk answers to it tomorrow", () => {
+    // The whole point. /dev/sdb1 is a slot in this boot's enumeration order,
+    // and `identify` falls back to one whenever no uuid is published.
+    for (const id of ["/dev/sdb1", "/dev/disk4s1", "/dev/nvme0n1p2", "/dev/mapper/vg-lv"]) {
+      expect(identityIsProof(withIdentity(id)), id).toBe(false);
+    }
+  });
+
+  test("no identity at all is not proof", () => {
+    expect(identityIsProof(withIdentity(""))).toBe(false);
+    expect(identityIsProof({ ...target("ext") } as Target)).toBe(false);
+  });
+});
+
+describeRsync("a recorded identity, against the real mount table", () => {
+  /**
+   * The fixture lives on this machine's boot volume, so `identify` answers
+   * for it with whatever that volume publishes — which differs by machine and
+   * is the point: a uuid on macOS, a uuid on a Linux box running udev, and
+   * `/dev/root` on a cloud image whose initramfs named it that. None of these
+   * assertions may depend on which one it is.
+   */
+  const recorded = async (sentinel: string | undefined): Promise<Target> => {
     const found = await identify(join(root, "ext"));
     return {
       ...target("ext"),
       identity: found!.id,
-      ...(kind !== undefined ? { identityKind: kind } : {}),
+      identityKind: found!.kind,
       ...(sentinel !== undefined ? { sentinel } : {}),
     } as Target;
   };
 
-  test("a volume uuid stands on its own, sentinel or no sentinel", async () => {
-    // A uuid names the filesystem; nothing else can answer to it. Checking
-    // the sentinel as well would cost a read for no proof gained, so a
-    // target whose sentinel has drifted is still reachable.
-    expect(await targetReachability(await withIdentity("volume-uuid", "not-the-one"))).toBe("ok");
+  test("a matching identity with no sentinel resolves, whatever kind it is", async () => {
+    // Including a device path. Refusing here would make syncy unusable on a
+    // machine that publishes no uuid, which is not the same thing as safer.
+    expect(await targetReachability(await recorded(undefined))).toBe("ok");
   });
 
-  test("a mount source is checked against the sentinel as well", async () => {
-    // The failure this closes: `identity` falls back to the device path when
-    // the kernel publishes no uuid — the common case on Linux — and
-    // /dev/sdb1 is a slot in this boot's enumeration order. Unplug the
-    // backup disk, plug a different one into the same port, and it answers
-    // to the same path with the same device node. Only the sentinel knows.
-    expect(await targetReachability(await withIdentity("mount-source", "not-the-one"))).toBe(
-      "mismatch",
-    );
+  test("a sentinel, where there is one, is what decides", async () => {
+    const t = await recorded("not-the-one");
+    if (identityIsProof(t)) {
+      // A uuid or a share name is a name for the volume; the sentinel adds
+      // nothing it does not already have.
+      expect(await targetReachability(t)).toBe("ok");
+    } else {
+      // A device path is not, so the sentinel outranks it — and this is the
+      // branch that used to report "ok" for a disk that had been swapped.
+      expect(await targetReachability(t)).toBe("mismatch");
+    }
   });
 
-  test("a mount source with the right sentinel is reachable", async () => {
-    const real = readFileSync(join(root, "ext", SENTINEL_NAME), "utf8").trim();
-    expect(await targetReachability(await withIdentity("mount-source", real))).toBe("ok");
-  });
-
-  test("a target recorded before identity_kind existed is treated as the weaker one", async () => {
-    expect(await targetReachability(await withIdentity(undefined, "not-the-one"))).toBe("mismatch");
-  });
-
-  test("a mount source with no sentinel to check is still reachable", async () => {
-    // No regression for a target that never had one: the identity is all
-    // there is, and it did match.
-    expect(await targetReachability(await withIdentity("mount-source", undefined))).toBe("ok");
+  test("and either way the directory still has to be there", async () => {
+    const t = { ...(await recorded(undefined)), path: join(root, "ext", "no-such-dir") } as Target;
+    expect(await targetReachability(t)).toBe("unreachable");
   });
 });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { type Config, parseConfig } from "../src/config.ts";
+import { type Config, parseConfig, type Target } from "../src/config.ts";
 import { fingerprint } from "../src/fingerprint.ts";
 import { checkBuild, DEFAULT_RSYNC } from "../src/rsync.ts";
 import { allReachability, checkUnit, listUnits, targetReachability } from "../src/scan.ts";
 import { SENTINEL_NAME, writeSentinel } from "../src/sentinel.ts";
 import { EMPTY_STATE, type State, upsertScan } from "../src/state.ts";
 import { evaluateUnit } from "../src/status.ts";
+import { identify } from "../src/volume.ts";
 import { makeFixtureDir, removeFixtureDir } from "./helpers.ts";
 
 /**
@@ -112,6 +113,62 @@ describeRsync("units and reachability", () => {
   test("a different volume mounted at the same path is detected", async () => {
     writeFileSync(join(target("ext").path, SENTINEL_NAME), "some-other-uuid\n");
     expect(await targetReachability(target("ext"))).toBe("mismatch");
+  });
+});
+
+/**
+ * What a recorded identity is worth depends on what kind of identity it is.
+ *
+ * The identity of the fixture path is whatever this machine actually answers
+ * for it, so these run the real `checkVolume` against the real mount table on
+ * either platform; only the recorded `identityKind` varies, which is the
+ * thing under test.
+ */
+describeRsync("a mount-source identity does not outrank the sentinel", () => {
+  const withIdentity = async (
+    kind: "volume-uuid" | "mount-source" | undefined,
+    sentinel: string | undefined,
+  ): Promise<Target> => {
+    const found = await identify(join(root, "ext"));
+    return {
+      ...target("ext"),
+      identity: found!.id,
+      ...(kind !== undefined ? { identityKind: kind } : {}),
+      ...(sentinel !== undefined ? { sentinel } : {}),
+    } as Target;
+  };
+
+  test("a volume uuid stands on its own, sentinel or no sentinel", async () => {
+    // A uuid names the filesystem; nothing else can answer to it. Checking
+    // the sentinel as well would cost a read for no proof gained, so a
+    // target whose sentinel has drifted is still reachable.
+    expect(await targetReachability(await withIdentity("volume-uuid", "not-the-one"))).toBe("ok");
+  });
+
+  test("a mount source is checked against the sentinel as well", async () => {
+    // The failure this closes: `identity` falls back to the device path when
+    // the kernel publishes no uuid — the common case on Linux — and
+    // /dev/sdb1 is a slot in this boot's enumeration order. Unplug the
+    // backup disk, plug a different one into the same port, and it answers
+    // to the same path with the same device node. Only the sentinel knows.
+    expect(await targetReachability(await withIdentity("mount-source", "not-the-one"))).toBe(
+      "mismatch",
+    );
+  });
+
+  test("a mount source with the right sentinel is reachable", async () => {
+    const real = readFileSync(join(root, "ext", SENTINEL_NAME), "utf8").trim();
+    expect(await targetReachability(await withIdentity("mount-source", real))).toBe("ok");
+  });
+
+  test("a target recorded before identity_kind existed is treated as the weaker one", async () => {
+    expect(await targetReachability(await withIdentity(undefined, "not-the-one"))).toBe("mismatch");
+  });
+
+  test("a mount source with no sentinel to check is still reachable", async () => {
+    // No regression for a target that never had one: the identity is all
+    // there is, and it did match.
+    expect(await targetReachability(await withIdentity("mount-source", undefined))).toBe("ok");
   });
 });
 

--- a/test/proc-mounts.test.ts
+++ b/test/proc-mounts.test.ts
@@ -83,17 +83,19 @@ const proc = (device: string, mountPoint: string, fstype: string, local: boolean
  * Every path the Linux volume code touches goes through this, so a test
  * cannot pass by reading the machine it runs on — which is the whole reason
  * these decisions take an io object. An unlisted path does not exist:
- * `realpath` of an unknown path returns it unchanged, the way a real
- * non-symlink resolves to itself.
+ * `realpath` of an unknown path returns null, the way a path with nothing
+ * behind it does — which is exactly the /dev/root case below.
  */
 const io = (
   files: Record<string, string>,
   links: Record<string, string> = {},
   dirs: Record<string, string[]> = {},
+  devnums: Record<string, number> = {},
 ): LinuxVolumeIo => ({
   readText: (path) => files[path] ?? null,
   list: (dir) => dirs[dir] ?? [],
-  realpath: (path) => links[path] ?? path,
+  realpath: (path) => links[path] ?? null,
+  deviceNumber: (path) => devnums[path] ?? null,
 });
 
 describe("classifying Linux mounts", () => {
@@ -133,25 +135,39 @@ describe("classifying Linux mounts", () => {
     // half of that path is right. /sys/block holds whole disks only, and a
     // partition publishes no `removable` of its own — so the file never
     // existed on any machine and every external disk read as internal.
-    const usb = io({ "/sys/class/block/sdb1/../removable": "1" });
+    const usb = io({ "/sys/class/block/sdb1/../removable": "1" }, { "/dev/sdb1": "/dev/sdb1" });
     expect(isRemovableDevice("/dev/sdb1", usb)).toBe(true);
     expect(classifyLinuxDevice("/dev/sdb1", usb)).toBe("external");
   });
 
   test("a whole disk answers from its own directory", () => {
-    expect(isRemovableDevice("/dev/sdb", io({ "/sys/class/block/sdb/removable": "1" }))).toBe(true);
+    expect(
+      isRemovableDevice(
+        "/dev/sdb",
+        io({ "/sys/class/block/sdb/removable": "1" }, { "/dev/sdb": "/dev/sdb" }),
+      ),
+    ).toBe(true);
   });
 
   test("an internal partition is internal, and a missing file is not removable", () => {
     expect(
-      isRemovableDevice("/dev/nvme0n1p2", io({ "/sys/class/block/nvme0n1p2/../removable": "0" })),
+      isRemovableDevice(
+        "/dev/nvme0n1p2",
+        io(
+          { "/sys/class/block/nvme0n1p2/../removable": "0" },
+          { "/dev/nvme0n1p2": "/dev/nvme0n1p2" },
+        ),
+      ),
     ).toBe(false);
-    expect(isRemovableDevice("/dev/sdb1", io({}))).toBe(false);
+    expect(isRemovableDevice("/dev/sdb1", io({}, { "/dev/sdb1": "/dev/sdb1" }))).toBe(false);
   });
 
   test("the removable bit is trimmed: sysfs files end in a newline", () => {
     expect(
-      isRemovableDevice("/dev/sdb1", io({ "/sys/class/block/sdb1/../removable": " 1 " })),
+      isRemovableDevice(
+        "/dev/sdb1",
+        io({ "/sys/class/block/sdb1/../removable": " 1 " }, { "/dev/sdb1": "/dev/sdb1" }),
+      ),
     ).toBe(true);
   });
 });
@@ -212,6 +228,25 @@ describe("volume UUID on Linux", () => {
       },
     );
     expect(volumeUuidLinux(ghost("/dev/mapper/vg-lv", "ext4"), dm)).toBe("LVM-abc123");
+  });
+
+  test("a device with no node — /dev/root — is found by its device number", () => {
+    // What the CI runners actually mount: an initramfs names the root
+    // filesystem /dev/root and no such node exists, so resolving the name
+    // gets nowhere. The mount's device number is real, and
+    // /sys/dev/block/<major>:<minor> resolves to the kernel's own name for
+    // it. Without this route the most likely mount on the machine has no
+    // uuid at all — which is what CI reported. 8:1 is sda1.
+    const runner = io(
+      {},
+      {
+        "/sys/dev/block/8:1": "/sys/devices/pci0000:00/x/block/sda/sda1",
+        "/dev/disk/by-uuid/root-fs-uuid": "/dev/sda1",
+      },
+      { "/dev/disk/by-uuid": ["root-fs-uuid"] },
+      { "/": (8 << 8) | 1 },
+    );
+    expect(volumeUuidLinux(proc("/dev/root", "/", "ext4", true), runner)).toBe("root-fs-uuid");
   });
 
   test("nothing published means null, and the caller must not treat the path as proof", () => {

--- a/test/proc-mounts.test.ts
+++ b/test/proc-mounts.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { type MountEntry, parseProcMounts } from "../src/fstype.ts";
+import { classify, classifyLinuxDevice, isRemovableBlock, volumeUuidLinux } from "../src/volume.ts";
+
+/**
+ * The Linux side of volume identity, tested against a fixed /proc/mounts
+ * table and an injected sysfs reader.
+ *
+ * The parsers and decisions are pure; the only real I/O is reading
+ * /proc/mounts and the sysfs files, which is exactly what the reader
+ * injection replaces. A machine without a second disk still gets the full
+ * suite.
+ */
+
+describe("parsing /proc/mounts", () => {
+  const MOUNTS = `tmpfs /run tmpfs rw,nosuid,nodev,size=6292836k 0 0
+/dev/nvme1n1p2 / ext4 rw,relatime 0 0
+//nas.local/media /mnt/media cifs rw,vers=3.11,uid=1000 0 0
+archive.example:/exports/videos /mnt/nfs nfs rw,hard 0 0
+/dev/loop0 /mnt/image squashfs ro 0 0
+/dev/sdb1 /mnt/usb exfat rw 0 0
+overlay /var/lib/docker/overlay2/x/merged overlay rw 0 0`;
+
+  test("splits fields and keeps the options", () => {
+    const entries = parseProcMounts(MOUNTS);
+    expect(entries).toHaveLength(7);
+    expect(entries[1]).toEqual({
+      device: "/dev/nvme1n1p2",
+      mountPoint: "/",
+      fstype: "ext4",
+      flags: ["rw", "relatime"],
+      local: true,
+    });
+  });
+
+  test("network shares are not local, whatever their device is", () => {
+    const entries = parseProcMounts(MOUNTS);
+    expect(entries.find((e) => e.mountPoint === "/mnt/media")?.local).toBe(false);
+    expect(entries.find((e) => e.mountPoint === "/mnt/nfs")?.local).toBe(false);
+  });
+
+  test("a block device and a pseudo-filesystem are both local", () => {
+    const entries = parseProcMounts(MOUNTS);
+    expect(entries.find((e) => e.mountPoint === "/run")?.local).toBe(true);
+    expect(entries.find((e) => e.mountPoint === "/mnt/usb")?.local).toBe(true);
+  });
+
+  test("octal-escaped spaces in a mount point survive", () => {
+    const entries = parseProcMounts("/dev/sdd1 /mnt/odd\\040name vfat rw 0 0");
+    expect(entries[0]?.mountPoint).toBe("/mnt/odd name");
+  });
+
+  test("a share whose name contains a space is one entry", () => {
+    // In /proc/mounts a space in the mount source is octal-escaped.
+    const entries = parseProcMounts("file:/remote\\040dir /mnt/remote fuse.sshfs rw 0 0");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.device).toBe("file:/remote dir");
+    expect(entries[0]?.fstype).toBe("fuse.sshfs");
+  });
+
+  test("garbage lines yield nothing rather than a wrong entry", () => {
+    expect(parseProcMounts("not a mount line\n\n   \n")).toEqual([]);
+  });
+});
+
+const proc = (device: string, mountPoint: string, fstype: string, local: boolean): MountEntry => ({
+  device,
+  mountPoint,
+  fstype,
+  flags: [],
+  local,
+});
+
+describe("classifying Linux mounts", () => {
+  test("a network fstype is a share on any mount table", () => {
+    expect(classify(proc("//nas.local/media", "/mnt/media", "cifs", false))).toBe("network");
+    expect(classify(proc("archive.example:/exports", "/mnt/nfs", "nfs", false))).toBe("network");
+    expect(classify(proc("file:/remote", "/mnt/ssh", "fuse.sshfs", false))).toBe("network");
+  });
+
+  test("loop devices are unknown: the vocabulary has no word for images", () => {
+    // Loop devices back mounted disk images, not hardware. "external" and
+    // "internal" are claims about hardware, and the VolumeKind vocabulary
+    // dropped "image" (unreachable on macOS — see classify), so the honest
+    // answer for a loop mount is unknown.
+    expect(classifyLinuxDevice("/dev/loop0")).toBe("unknown");
+  });
+
+  test("no block device at all is not a destination", () => {
+    expect(classifyLinuxDevice("overlay")).toBe("unknown");
+    expect(classifyLinuxDevice("zfs")).toBe("unknown");
+  });
+
+  test("a mapper volume is an internal disk", () => {
+    // `mapper` is not a block device name, so /sys has no removable bit for
+    // it on any machine, which makes the answer stable rather than a probe.
+    expect(classifyLinuxDevice("/dev/mapper/vg-lv")).toBe("internal");
+  });
+
+  test("removable comes from /sys, and no such file means not removable", () => {
+    expect(isRemovableBlock("sdb1", () => "1")).toBe(true);
+    expect(isRemovableBlock("sdb1", () => "0")).toBe(false);
+    expect(isRemovableBlock("sdb1", () => null)).toBe(false);
+    expect(isRemovableBlock("sdb1", () => " 1 ")).toBe(true);
+  });
+});
+
+describe("volume UUID from sysfs", () => {
+  // A mount point that cannot exist, so the devnum route never touches a real
+  // device and only the injected reader answers.
+  const ghost = (device: string, fstype: string): MountEntry =>
+    proc(device, "/mnt/no/such/point", fstype, true);
+
+  test("the uuid file wins for the device name", () => {
+    const reader = (p: string): string | null =>
+      p === "/sys/block/sdb1/uuid" ? "ABCD-1234-ABCD" : null;
+    expect(volumeUuidLinux(ghost("/dev/sdb1", "ext4"), reader)).toBe("ABCD-1234-ABCD");
+  });
+
+  test("partuuid answers for FAT-family devices", () => {
+    const reader = (p: string): string | null =>
+      p === "/sys/block/sdb1/partuuid" ? "1122-3344" : null;
+    expect(volumeUuidLinux(ghost("/dev/sdb1", "exfat"), reader)).toBe("1122-3344");
+  });
+
+  test("no published uuid means the caller falls back to the device path", () => {
+    expect(volumeUuidLinux(ghost("/dev/sdb1", "xfs"), () => null)).toBeNull();
+  });
+
+  test("mapper names have no name-based route and no devnum on a ghost", () => {
+    expect(
+      volumeUuidLinux(ghost("/dev/mapper/vg-lv", "ext4"), () => "should-not-be-read"),
+    ).toBeNull();
+  });
+});

--- a/test/proc-mounts.test.ts
+++ b/test/proc-mounts.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { type MountEntry, parseProcMounts } from "../src/fstype.ts";
-import { classify, classifyLinuxDevice, isRemovableBlock, volumeUuidLinux } from "../src/volume.ts";
+import {
+  classify,
+  classifyLinuxDevice,
+  isRemovableDevice,
+  type LinuxVolumeIo,
+  volumeUuidLinux,
+} from "../src/volume.ts";
 
 /**
  * The Linux side of volume identity, tested against a fixed /proc/mounts
@@ -71,6 +77,25 @@ const proc = (device: string, mountPoint: string, fstype: string, local: boolean
   local,
 });
 
+/**
+ * A canned /sys and /dev/disk.
+ *
+ * Every path the Linux volume code touches goes through this, so a test
+ * cannot pass by reading the machine it runs on — which is the whole reason
+ * these decisions take an io object. An unlisted path does not exist:
+ * `realpath` of an unknown path returns it unchanged, the way a real
+ * non-symlink resolves to itself.
+ */
+const io = (
+  files: Record<string, string>,
+  links: Record<string, string> = {},
+  dirs: Record<string, string[]> = {},
+): LinuxVolumeIo => ({
+  readText: (path) => files[path] ?? null,
+  list: (dir) => dirs[dir] ?? [],
+  realpath: (path) => links[path] ?? path,
+});
+
 describe("classifying Linux mounts", () => {
   test("a network fstype is a share on any mount table", () => {
     expect(classify(proc("//nas.local/media", "/mnt/media", "cifs", false))).toBe("network");
@@ -83,53 +108,118 @@ describe("classifying Linux mounts", () => {
     // "internal" are claims about hardware, and the VolumeKind vocabulary
     // dropped "image" (unreachable on macOS — see classify), so the honest
     // answer for a loop mount is unknown.
-    expect(classifyLinuxDevice("/dev/loop0")).toBe("unknown");
+    expect(classifyLinuxDevice("/dev/loop0", io({}))).toBe("unknown");
   });
 
   test("no block device at all is not a destination", () => {
-    expect(classifyLinuxDevice("overlay")).toBe("unknown");
-    expect(classifyLinuxDevice("zfs")).toBe("unknown");
+    expect(classifyLinuxDevice("overlay", io({}))).toBe("unknown");
+    expect(classifyLinuxDevice("zfs", io({}))).toBe("unknown");
   });
 
-  test("a mapper volume is an internal disk", () => {
-    // `mapper` is not a block device name, so /sys has no removable bit for
-    // it on any machine, which makes the answer stable rather than a probe.
-    expect(classifyLinuxDevice("/dev/mapper/vg-lv")).toBe("internal");
+  test("a mapper volume is asked about as the dm-N it resolves to", () => {
+    // /dev/mapper/vg-lv is a symlink; /sys/class/block has no `mapper`. The
+    // realpath is what has a removable bit, and an LVM volume's is 0.
+    const links = { "/dev/mapper/vg-lv": "/dev/dm-0" };
+    expect(
+      classifyLinuxDevice(
+        "/dev/mapper/vg-lv",
+        io({ "/sys/class/block/dm-0/removable": "0" }, links),
+      ),
+    ).toBe("internal");
   });
 
-  test("removable comes from /sys, and no such file means not removable", () => {
-    expect(isRemovableBlock("sdb1", () => "1")).toBe(true);
-    expect(isRemovableBlock("sdb1", () => "0")).toBe(false);
-    expect(isRemovableBlock("sdb1", () => null)).toBe(false);
-    expect(isRemovableBlock("sdb1", () => " 1 ")).toBe(true);
+  test("a USB partition is external: `removable` lives on the disk, not the partition", () => {
+    // The bug this replaces: /sys/block/sdb1/removable was read, and neither
+    // half of that path is right. /sys/block holds whole disks only, and a
+    // partition publishes no `removable` of its own — so the file never
+    // existed on any machine and every external disk read as internal.
+    const usb = io({ "/sys/class/block/sdb1/../removable": "1" });
+    expect(isRemovableDevice("/dev/sdb1", usb)).toBe(true);
+    expect(classifyLinuxDevice("/dev/sdb1", usb)).toBe("external");
+  });
+
+  test("a whole disk answers from its own directory", () => {
+    expect(isRemovableDevice("/dev/sdb", io({ "/sys/class/block/sdb/removable": "1" }))).toBe(true);
+  });
+
+  test("an internal partition is internal, and a missing file is not removable", () => {
+    expect(
+      isRemovableDevice("/dev/nvme0n1p2", io({ "/sys/class/block/nvme0n1p2/../removable": "0" })),
+    ).toBe(false);
+    expect(isRemovableDevice("/dev/sdb1", io({}))).toBe(false);
+  });
+
+  test("the removable bit is trimmed: sysfs files end in a newline", () => {
+    expect(
+      isRemovableDevice("/dev/sdb1", io({ "/sys/class/block/sdb1/../removable": " 1 " })),
+    ).toBe(true);
   });
 });
 
-describe("volume UUID from sysfs", () => {
-  // A mount point that cannot exist, so the devnum route never touches a real
-  // device and only the injected reader answers.
+describe("volume UUID on Linux", () => {
   const ghost = (device: string, fstype: string): MountEntry =>
     proc(device, "/mnt/no/such/point", fstype, true);
 
-  test("the uuid file wins for the device name", () => {
-    const reader = (p: string): string | null =>
-      p === "/sys/block/sdb1/uuid" ? "ABCD-1234-ABCD" : null;
-    expect(volumeUuidLinux(ghost("/dev/sdb1", "ext4"), reader)).toBe("ABCD-1234-ABCD");
+  test("the filesystem uuid comes from udev's by-uuid symlinks", () => {
+    // Not from sysfs: a filesystem uuid lives in the superblock, and the
+    // kernel publishes none for a block device. udev resolves it and links
+    // it under /dev/disk/by-uuid, which is what `blkid` and every mount unit
+    // on the machine already agree is the name for the volume.
+    const found = io(
+      {},
+      { "/dev/disk/by-uuid/8f3b-ARCHIVE": "/dev/sdb1", "/dev/sdb1": "/dev/sdb1" },
+      { "/dev/disk/by-uuid": ["8f3b-ARCHIVE", "other-volume"] },
+    );
+    expect(volumeUuidLinux(ghost("/dev/sdb1", "ext4"), found)).toBe("8f3b-ARCHIVE");
   });
 
-  test("partuuid answers for FAT-family devices", () => {
-    const reader = (p: string): string | null =>
-      p === "/sys/block/sdb1/partuuid" ? "1122-3344" : null;
-    expect(volumeUuidLinux(ghost("/dev/sdb1", "exfat"), reader)).toBe("1122-3344");
+  test("by-partuuid answers when the filesystem publishes no uuid", () => {
+    const found = io(
+      {},
+      { "/dev/disk/by-partuuid/1122-3344": "/dev/sdb1", "/dev/sdb1": "/dev/sdb1" },
+      { "/dev/disk/by-uuid": [], "/dev/disk/by-partuuid": ["1122-3344"] },
+    );
+    expect(volumeUuidLinux(ghost("/dev/sdb1", "exfat"), found)).toBe("1122-3344");
   });
 
-  test("no published uuid means the caller falls back to the device path", () => {
-    expect(volumeUuidLinux(ghost("/dev/sdb1", "xfs"), () => null)).toBeNull();
+  test("a link that resolves elsewhere is not this volume's uuid", () => {
+    // The whole point of resolving both sides: by-uuid is full of entries,
+    // and only the one pointing at *this* node names *this* volume.
+    const other = io(
+      {},
+      { "/dev/disk/by-uuid/belongs-to-sda1": "/dev/sda1", "/dev/sdb1": "/dev/sdb1" },
+      { "/dev/disk/by-uuid": ["belongs-to-sda1"] },
+    );
+    expect(volumeUuidLinux(ghost("/dev/sdb1", "ext4"), other)).toBeNull();
   });
 
-  test("mapper names have no name-based route and no devnum on a ghost", () => {
-    expect(
-      volumeUuidLinux(ghost("/dev/mapper/vg-lv", "ext4"), () => "should-not-be-read"),
-    ).toBeNull();
+  test("a device that publishes its own uuid answers without udev", () => {
+    // An NVMe namespace and a device-mapper volume do have a uuid in sysfs,
+    // which covers a machine running without udev. /sys/class/block, not
+    // /sys/block: the latter holds whole disks only.
+    const nvme = io(
+      { "/sys/class/block/nvme0n1/uuid": "nvme-namespace-uuid" },
+      {
+        "/dev/nvme0n1": "/dev/nvme0n1",
+      },
+    );
+    expect(volumeUuidLinux(ghost("/dev/nvme0n1", "ext4"), nvme)).toBe("nvme-namespace-uuid");
+
+    const dm = io(
+      { "/sys/class/block/dm-0/dm/uuid": "LVM-abc123" },
+      {
+        "/dev/mapper/vg-lv": "/dev/dm-0",
+      },
+    );
+    expect(volumeUuidLinux(ghost("/dev/mapper/vg-lv", "ext4"), dm)).toBe("LVM-abc123");
+  });
+
+  test("nothing published means null, and the caller must not treat the path as proof", () => {
+    expect(volumeUuidLinux(ghost("/dev/sdb1", "xfs"), io({}))).toBeNull();
+  });
+
+  test("a source that is not a device node has no uuid to look up", () => {
+    expect(volumeUuidLinux(ghost("overlay", "overlay"), io({}))).toBeNull();
+    expect(volumeUuidLinux(ghost("//nas/media", "cifs"), io({}))).toBeNull();
   });
 });


### PR DESCRIPTION
The same safety invariants, mapped onto the kernel's own interfaces (DESIGN.md gains section 10).

- **`src/platform.ts`** — one branch point for the platform questions
- **`rsync`** — the distribution `/usr/bin/rsync` on Linux; macOS still never uses `/usr/bin` (openrsync), and the build-time check still refuses anything older than 3.x
- **`fstype`** — parses `/proc/mounts` (in memory: no spawn, no stall on a dead share); octal-escaped mount points; pseudo-filesystem list
- **`volume`** — identity from sysfs `uuid`/`partuuid`, with a devnum route for namespaced `/sys`; the device path as mount-source when the kernel publishes nothing; external vs internal from `/sys/block/<n>/removable`; the setup screen's volume list filters pseudo-filesystems on Linux
- **`probe`** — `setfattr`/`getfattr` and `setfacl`/`getfacl` (pinned, `/usr/bin` then `/bin`); a missing or failed tool marks the capability *unmeasurable* and drops its flag, and the `get` is skipped for it so one absent tool cannot fail the measurement of the others
- **`clipboard`** — `pbcopy` on macOS, `wl-copy`/`xclip`/`xsel` on Linux; absence is reported, not thrown

**One vocabulary decision.** The audit work on main removed the `"image"` volume kind (a dead branch on macOS), and a loop device is the one local device class that kind described. `"external"` and `"internal"` are claims about hardware, and a mounted image is not hardware — so `/dev/loop*` classifies as **`unknown`**.

**Tests.** `parseProcMounts` and the sysfs-backed identity decisions are covered by `test/proc-mounts.test.ts` against a fixed table and an injected reader, so the suite passes with no second disk attached. The suite still runs real rsync against real files on both CI platforms.