### PR TITLE
refactor: extract useJob and useKeys from App

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,22 +1,15 @@
 import { join } from "node:path";
-import { Box, Text, useApp, useInput, useStdout } from "ink";
+import { Box, Text, useApp, useStdout } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { copyToClipboard } from "../clipboard.ts";
 import type { Config } from "../config.ts";
-import { buildDiff, type Diff, loadDiff, saveDiff } from "../diff.ts";
+import { type Diff, loadDiff } from "../diff.ts";
 import { EMPTY as EMPTY_FINGERPRINT, type Fingerprint, fingerprint } from "../fingerprint.ts";
 import { bytes } from "../format.ts";
-import { debug, timed, timedAsync } from "../log.ts";
-import { allReachability, checkUnit, listUnits, methodOf, type Reachability } from "../scan.ts";
-import {
-  appendHistory,
-  estimateMs,
-  lastSyncAt,
-  loadState,
-  type State,
-  saveState,
-  upsertScan,
-} from "../state.ts";
-import { type CellState, evaluateUnit, reachWord, type UnitState } from "../status.ts";
+import { timed, timedAsync } from "../log.ts";
+import { allReachability, listUnits, type Reachability } from "../scan.ts";
+import { lastSyncAt, loadState, type State } from "../state.ts";
+import { type CellState, evaluateUnit, type UnitState } from "../status.ts";
 import { setTitle, titleFor } from "../title.ts";
 import { padEnd, truncatePath } from "../width.ts";
 import { Confirm } from "./Confirm.tsx";
@@ -25,18 +18,22 @@ import { Job } from "./Job.tsx";
 import { Ledger, type Row } from "./Ledger.tsx";
 import { Mark } from "./Mark.tsx";
 import { Plan } from "./Plan.tsx";
-import { barFraction, type RunProgress } from "./Progress.tsx";
+import { barFraction } from "./Progress.tsx";
 import { Rule, Screen } from "./Screen.tsx";
 import { Setup } from "./Setup.tsx";
 import { cellToken, resolveTheme } from "./theme.ts";
+import { useJob } from "./useJob.ts";
+import { useKeys } from "./useKeys.ts";
 import { useScreen } from "./useScreen.ts";
 
 /**
- * Phase 2: the ledger, read-only plus the two non-destructive checks.
+ * The ledger: screens, selection and the composition of what each key does.
  *
- * Quick and deep both run with -n and never write to a target, so they are safe
- * to bind to a keypress. Actual syncing is phase 3 and goes behind the confirm
- * page with its guard rails.
+ * The work is not here. Running a check — the job list, its byte-based bar,
+ * the per-destination skips, the state and history writes — lives in useJob,
+ * and the keyboard decision, which screen owns it right now, lives in useKeys.
+ * What remains is the state the screens share and the render: selection,
+ * filters, the overlay screens, the window title.
  */
 
 const FILTERS: ReadonlyArray<UnitState | "all"> = [
@@ -71,14 +68,6 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
   );
   const [selected, setSelected] = useState(0);
   const [filter, setFilter] = useState(0);
-  const [busy, setBusy] = useState<string | null>(null);
-  /**
-   * What is being checked right now.
-   *
-   * Held separately from `busy` — which is a transient message — so the work
-   * stays visible on the row it belongs to even after the cursor moves away.
-   */
-  const [running, setRunning] = useState<RunProgress | null>(null);
   const [showHelp, setShowHelp] = useState(false);
   const [showEvidence, setShowEvidence] = useState(false);
   const [showDiff, setShowDiff] = useState(false);
@@ -123,6 +112,10 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
   }, [runningSync]);
   const [now, setNow] = useState(() => Date.now());
   const [frame, setFrame] = useState(0);
+  // The plan's copy feedback lands on the ledger's busy line, like everything
+  // else the ledger says. Merged rather than nested: the plan screen is up
+  // while the copy happens, and the line is what is read after [esc].
+  const [planStatus, setPlanStatus] = useState<string | null>(null);
 
   const screen = useScreen(stdout);
   const width = screen.width;
@@ -168,29 +161,6 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
     refresh();
   }, [refresh]);
 
-  // While a run is in flight the elapsed time has to keep moving, or the
-  // interface looks frozen even though work is happening.
-  useEffect(() => {
-    if (running === null) return;
-    const clock = setInterval(() => setNow(Date.now()), 500);
-    // Faster than the clock, so the forklift reads as motion. Costs nothing
-    // when idle because the interval only exists while something runs.
-    const anim = setInterval(() => setFrame((f) => f + 1), 220);
-    return () => {
-      clearInterval(clock);
-      clearInterval(anim);
-    };
-  }, [running]);
-
-  /**
-   * Rows are pure evaluation against cached facts — no filesystem work at all.
-   *
-   * This used to fingerprint every folder and read every sentinel on each
-   * render. Fingerprinting a real archive measured 645 ms, and the progress
-   * ticker moves `now` every 500 ms during a check, so the interface spent more
-   * than all of its time re-walking the disk and never got round to drawing.
-   * It looked exactly like a hang.
-   */
   const allRows: Row[] = useMemo(() => {
     if (config.source === "" || config.targets.length === 0 || scan === null) return [];
     return units.map((unit) => {
@@ -206,6 +176,33 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
   const active = FILTERS[filter] ?? "all";
   const rows = active === "all" ? allRows : allRows.filter((r) => r.status.state === active);
   const clampedSelection = Math.min(selected, Math.max(0, rows.length - 1));
+
+  const job = useJob({
+    config,
+    rows,
+    clampedSelection,
+    state,
+    scan,
+    refresh,
+    notify: showNotice,
+    setNow,
+    setState,
+  });
+  const { running, busy, runCheck } = job;
+
+  // While a run is in flight the elapsed time has to keep moving, or the
+  // interface looks frozen even though work is happening.
+  useEffect(() => {
+    if (running === null) return;
+    const clock = setInterval(() => setNow(Date.now()), 500);
+    // Faster than the clock, so the forklift reads as motion. Costs nothing
+    // when idle because the interval only exists while something runs.
+    const anim = setInterval(() => setFrame((f) => f + 1), 220);
+    return () => {
+      clearInterval(clock);
+      clearInterval(anim);
+    };
+  }, [running]);
 
   /**
    * Keep the window title current.
@@ -257,242 +254,72 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
     return new Map(config.targets.map((t) => [t.name, lastSyncAt(unit, t.name)]));
   }, [showDiff, rows, clampedSelection, config.targets, state]);
 
-  const runCheck = useCallback(
-    async (mode: "quick" | "deep", scope: "selected" | "all") => {
-      if (running !== null) {
-        showNotice(
-          `[${mode === "deep" ? "d" : "q"}] ignored — the ${running.mode} check on ` +
-            `${running.unit} is still running`,
-        );
-        return;
-      }
-      const chosen = scope === "all" ? rows : rows.slice(clampedSelection, clampedSelection + 1);
-      if (chosen.length === 0) return;
-
-      const reach = scan?.reach ?? (await allReachability(config));
-      const jobs = chosen.flatMap((row) =>
-        config.targets.map((target) => ({
-          unit: row.status.unit,
-          target,
-          size: row.size,
-          files: row.files ?? 0,
-        })),
-      );
-      // The bar fills by bytes: a 78 gb folder and a 442 mb one take wildly
-      // different times, so counting folders equally would make it lie.
-      const bytesTotal = jobs.reduce((a, j) => a + j.size, 0);
-      const startedAt = Date.now();
-      let working = state;
-      let done = 0;
-      let bytesDone = 0;
-
-      // Destinations that could not be reached, so the run can say what it did
-      // not do. Skipping in silence and then reporting "deep check finished"
-      // was a claim that nothing had been checked — indistinguishable from a
-      // check that never started.
-      const skipped: { readonly target: string; readonly why: Reachability }[] = [];
-
-      for (const job of jobs) {
-        const status = reach.get(job.target.name);
-        if (status !== "ok") {
-          if (!skipped.some((s) => s.target === job.target.name)) {
-            skipped.push({ target: job.target.name, why: status ?? "unreachable" });
+  useKeys(
+    showHelp
+      ? "help"
+      : showEvidence
+        ? "evidence"
+        : showDiff || showPlan || showSetup || pendingSync !== null || runningSync !== null
+          ? "inert"
+          : "ledger",
+    {
+      controlC: () => {
+        // While a transfer is running, the first press is Job's to act on: let
+        // it cancel and render the outcome instead of the app vanishing under
+        // it. A second press exits regardless of what the transfer is doing.
+        if (runningSync !== null) {
+          ctrlCPresses.current += 1;
+          if (ctrlCPresses.current < 2) return;
+        }
+        exit();
+      },
+      closeHelp: () => setShowHelp(false),
+      closeEvidence: () => setShowEvidence(false),
+      ledger: {
+        up: () => setSelected((s) => Math.max(0, s - 1)),
+        down: () => setSelected((s) => Math.min(rows.length - 1, s + 1)),
+        quick: () => void runCheck("quick", "selected"),
+        quickAll: () => void runCheck("quick", "all"),
+        deep: () => void runCheck("deep", "selected"),
+        deepAll: () => void runCheck("deep", "all"),
+        refresh,
+        cycleFilter: () => {
+          setFilter((f) => (f + 1) % FILTERS.length);
+          setSelected(0);
+        },
+        evidence: () => setShowEvidence(true),
+        openDiff: () => {
+          // Only open it when there is a row, or the keyboard guard in
+          // useKeys would swallow every key with nothing on screen.
+          if (rows[clampedSelection] !== undefined) setShowDiff(true);
+        },
+        openPlan: () => {
+          // Only open it when there is a folder to describe, or the keyboard
+          // guard in useKeys would swallow every key with nothing on screen.
+          if (rows[clampedSelection] !== undefined) setShowPlan(true);
+        },
+        startSync: () => {
+          // Offer the target that is furthest behind; there is nothing to sync
+          // to a target that is already clean.
+          // A sync writes; starting one while a check is reading the same tree
+          // would have the two disagree about what is there.
+          if (running !== null) {
+            showNotice(
+              `[s] ignored — the ${running.mode} check on ${running.unit} is still running`,
+            );
+            return;
           }
-          debug("check.skipped", { unit: job.unit, target: job.target.name, reach: status });
-          done += 1;
-          bytesDone += job.size;
-          continue;
-        }
-        // Estimated from measured throughput at this destination, so the bar
-        // works from the second check onwards on *any* folder rather than only
-        // on one that has been checked twice.
-        const prior = estimateMs(working, job.target.name, methodOf(mode), job.size);
-        const jobStarted = Date.now();
-        const base = {
-          unit: job.unit,
-          target: job.target.name,
-          mode,
-          done,
-          total: jobs.length,
-          bytesDone,
-          bytesTotal,
-          startedAt,
-          jobStartedAt: jobStarted,
-          filesTotal: job.files,
-          unitBytes: job.size,
-          ...(prior !== undefined ? { priorMs: prior } : {}),
-        } as const;
-        setRunning({ ...base, filesSeen: 0 });
-        debug("check.start", {
-          mode,
-          unit: job.unit,
-          target: job.target.name,
-          bytes: job.size,
-          files: job.files,
-          estimateMs: prior ?? null,
-        });
-        try {
-          const { scan, argv, items, targetFingerprint, exitCode } = await checkUnit(
-            config,
-            job.unit,
-            job.target,
-            mode,
-            {
-              // Throttled: one render per 25 files keeps a large folder from
-              // driving the render loop instead of the check.
-              onFile: (seen) => {
-                if (seen % 25 === 0) setRunning({ ...base, filesSeen: seen });
-              },
-            },
-          );
-          const jobMs = Date.now() - jobStarted;
-          debug("check.done", {
-            mode,
-            unit: job.unit,
-            target: job.target.name,
-            ms: jobMs,
-            bytes: job.size,
-            outcome: scan.outcome,
-            nChanges: scan.nChanges,
-            // A rate only where one was actually achieved. A quick check reads
-            // no file contents, so dividing the folder's bytes by its elapsed
-            // time reported 90,353 MB/s — a number with no referent. Sub-second
-            // runs are excluded for the same reason: the divisor is noise.
-            ...(mode === "deep" && jobMs >= 1000
-              ? { readMBPerSec: Math.round(job.size / 1e6 / (jobMs / 1000)) }
-              : {}),
-          });
-          working = upsertScan(working, scan);
-          saveState(working);
-          // The itemized list is what the differences screen shows. rsync
-          // produced it during the check; discarding it would mean re-running
-          // the whole check to answer "which files?".
-          saveDiff(
-            buildDiff(job.unit, job.target.name, scan.method, items, {
-              ts: scan.ts,
-              wholeFolderMissing: scan.outcome === "missing",
-              source: scan.fingerprint,
-              target: targetFingerprint,
-            }),
-          );
-          appendHistory({
-            ts: scan.ts,
-            unit: job.unit,
-            target: job.target.name,
-            argv,
-            exitCode,
-          });
-          // Publish after every unit so the ledger fills in as it goes rather
-          // than staying blank until the whole run finishes.
-          setState(working);
-          setNow(Date.now());
-        } catch (e) {
-          // Explicit catch at the subprocess boundary; a swallowed rejection
-          // would leave the ledger showing stale state as if it were fresh.
-          debug("check.failed", {
-            unit: job.unit,
-            target: job.target.name,
-            ms: Date.now() - jobStarted,
-            error: (e as Error).message,
-          });
-          setBusy(`${job.unit} → ${job.target.name}: failed — ${(e as Error).message}`);
-        }
-        done += 1;
-        bytesDone += job.size;
-      }
-
-      setRunning(null);
-      // A check can change what is at the target, and the source may have moved
-      // under us while it ran, so both facts are re-read once at the end.
-      refresh();
-      // A run in which every destination was skipped checked nothing, and must
-      // not report otherwise.
-      const ran =
-        jobs.length -
-        skipped.reduce((n, s) => n + jobs.filter((j) => j.target.name === s.target).length, 0);
-      if (ran === 0 && skipped.length > 0) {
-        setBusy(
-          `nothing checked — ${skipped.map((s) => `${s.target} ${reachWord(s.why)}`).join(", ")}`,
-        );
-      } else if (skipped.length > 0) {
-        setBusy(
-          `${mode} check finished · ${ran} of ${jobs.length} · skipped ` +
-            skipped.map((s) => `${s.target} (${reachWord(s.why)})`).join(", "),
-        );
-      } else {
-        setBusy(
-          scope === "all"
-            ? `${mode} check finished · ${chosen.length} folders`
-            : `${mode} check finished · ${chosen[0]?.status.unit ?? ""}`,
-        );
-      }
-      setNow(Date.now());
-      // A skip needs longer on screen than a success: it is the message the
-      // user has to read and act on.
-      setTimeout(() => setBusy(null), skipped.length > 0 ? 8000 : 2500);
+          const row = rows[clampedSelection];
+          const cell = row?.status.cells.find((c) => c.state === "behind" || c.state === "missing");
+          if (row !== undefined && cell !== undefined) {
+            setPendingSync({ unit: row.status.unit, target: cell.target });
+          }
+        },
+        setup: () => setShowSetup(true),
+        help: () => setShowHelp(true),
+      },
     },
-    [rows, clampedSelection, running, config, state, scan, refresh, showNotice],
   );
-
-  useInput((input, key) => {
-    if (key.ctrl && input === "c") {
-      // While a transfer is running, the first press is Job's to act on: let
-      // it cancel and render the outcome instead of the app vanishing under
-      // it. A second press exits regardless of what the transfer is doing.
-      if (runningSync !== null) {
-        ctrlCPresses.current += 1;
-        if (ctrlCPresses.current < 2) return;
-      }
-      return exit();
-    }
-    if (showHelp) {
-      setShowHelp(false);
-      return;
-    }
-    if (showEvidence) {
-      if (key.escape || input === "e") setShowEvidence(false);
-      return;
-    }
-    if (showDiff) return; // The differences screen owns the keyboard.
-    if (showPlan) return; // Plan owns the keyboard while it is open.
-    if (showSetup) return; // Setup owns the keyboard while it is open.
-    if (pendingSync !== null || runningSync !== null) return; // Confirm/Job own it.
-    if (key.upArrow || input === "k") setSelected((s) => Math.max(0, s - 1));
-    else if (key.downArrow || input === "j") setSelected((s) => Math.min(rows.length - 1, s + 1));
-    else if (input === "q") void runCheck("quick", "selected");
-    else if (input === "Q") void runCheck("quick", "all");
-    else if (input === "d") void runCheck("deep", "selected");
-    else if (input === "D") void runCheck("deep", "all");
-    else if (input === "r") refresh();
-    else if (input === "f") {
-      setFilter((f) => (f + 1) % FILTERS.length);
-      setSelected(0);
-    } else if (input === "e") setShowEvidence(true);
-    else if (key.return) {
-      // Enter on a row opens what differs about it. Guarded on there being a
-      // row, or the keyboard guard above would swallow every key.
-      if (rows[clampedSelection] !== undefined) setShowDiff(true);
-    } else if (input === "p") {
-      // Only open it when there is a folder to describe, or the keyboard guard
-      // above would swallow every key with nothing on screen.
-      if (rows[clampedSelection] !== undefined) setShowPlan(true);
-    } else if (input === "s") {
-      // Offer the target that is furthest behind; there is nothing to sync to a
-      // target that is already clean.
-      // A sync writes; starting one while a check is reading the same tree
-      // would have the two disagree about what is there.
-      if (running !== null) {
-        showNotice(`[s] ignored — the ${running.mode} check on ${running.unit} is still running`);
-        return;
-      }
-      const row = rows[clampedSelection];
-      const cell = row?.status.cells.find((c) => c.state === "behind" || c.state === "missing");
-      if (row !== undefined && cell !== undefined) {
-        setPendingSync({ unit: row.status.unit, target: cell.target });
-      }
-    } else if (input === ",") setShowSetup(true);
-    else if (input === "?") setShowHelp(true);
-  });
 
   const syncing = pendingSync ?? runningSync;
   const syncRow =
@@ -571,18 +398,12 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
           height={screen.rows}
           onClose={() => setShowPlan(false)}
           onCopy={(text) => {
-            // pbcopy is macOS-only; failing to copy must not take the app down.
-            try {
-              // Absolute, like every other binary syncy runs. Resolving this from
-              // PATH would have been the one place a planted executable could
-              // run — inconsistent with pinning rsync for exactly that reason.
-              Bun.spawn(["/usr/bin/pbcopy"], { stdin: new TextEncoder().encode(text) });
-              setBusy("plan copied to the clipboard");
-              setTimeout(() => setBusy(null), 1500);
-            } catch {
-              setBusy("could not reach pbcopy");
-              setTimeout(() => setBusy(null), 1500);
-            }
+            // Copying is best-effort: a machine with no clipboard tool says so
+            // rather than taking the app down.
+            void copyToClipboard(text).then((message) => {
+              setPlanStatus(message);
+              setTimeout(() => setPlanStatus(null), 1500);
+            });
           }}
         />
       );
@@ -682,7 +503,7 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
         width={width}
         height={screen.rows - (active === "all" ? 0 : 1)}
         now={now}
-        busy={busy}
+        busy={planStatus ?? busy}
         running={running}
         frame={frame}
         notice={notice}

--- a/src/tui/useJob.ts
+++ b/src/tui/useJob.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import type { Config } from "../config.ts";
 import { buildDiff, saveDiff } from "../diff.ts";
 import type { Fingerprint } from "../fingerprint.ts";
@@ -59,195 +59,199 @@ export function useJob(facts: JobFacts): Job {
    */
   const [running, setRunning] = useState<RunProgress | null>(null);
 
-  const runCheck = useCallback(
-    async (mode: "quick" | "deep", scope: "selected" | "all") => {
-      if (running !== null) {
-        facts.notify(
-          `[${mode === "deep" ? "d" : "q"}] ignored — the ${running.mode} check on ` +
-            `${running.unit} is still running`,
-        );
-        return;
-      }
-      const chosen =
-        scope === "all"
-          ? facts.rows
-          : facts.rows.slice(facts.clampedSelection, facts.clampedSelection + 1);
-      if (chosen.length === 0) return;
-
-      const reach = facts.scan?.reach ?? (await allReachability(facts.config));
-      const jobs = chosen.flatMap((row) =>
-        facts.config.targets.map((target) => ({
-          unit: row.status.unit,
-          target,
-          size: row.size,
-          files: row.files ?? 0,
-        })),
+  /**
+   * Not memoised, deliberately.
+   *
+   * `facts` is a fresh object every render and `rows` a fresh array whenever
+   * a filter is on, so a `useCallback` over them would rebuild the closure
+   * every render anyway — the memo would be a claim of stability that the
+   * dependencies cannot keep. Nothing depends on this function's identity:
+   * `useKeys` re-registers its handler each render regardless. A plain
+   * definition is what actually happens, so it is what is written.
+   */
+  const runCheck = async (mode: "quick" | "deep", scope: "selected" | "all"): Promise<void> => {
+    if (running !== null) {
+      facts.notify(
+        `[${mode === "deep" ? "d" : "q"}] ignored — the ${running.mode} check on ` +
+          `${running.unit} is still running`,
       );
-      // The bar fills by bytes: a 78 gb folder and a 442 mb one take wildly
-      // different times, so counting folders equally would make it lie.
-      const bytesTotal = jobs.reduce((a, j) => a + j.size, 0);
-      const startedAt = Date.now();
-      let working = facts.state;
-      let done = 0;
-      let bytesDone = 0;
+      return;
+    }
+    const chosen =
+      scope === "all"
+        ? facts.rows
+        : facts.rows.slice(facts.clampedSelection, facts.clampedSelection + 1);
+    if (chosen.length === 0) return;
 
-      // Destinations that could not be reached, so the run can say what it did
-      // not do. Skipping in silence and then reporting "deep check finished"
-      // was a claim that nothing had been checked — indistinguishable from a
-      // check that never started.
-      const skipped: { readonly target: string; readonly why: Reachability }[] = [];
+    const reach = facts.scan?.reach ?? (await allReachability(facts.config));
+    const jobs = chosen.flatMap((row) =>
+      facts.config.targets.map((target) => ({
+        unit: row.status.unit,
+        target,
+        size: row.size,
+        files: row.files ?? 0,
+      })),
+    );
+    // The bar fills by bytes: a 78 gb folder and a 442 mb one take wildly
+    // different times, so counting folders equally would make it lie.
+    const bytesTotal = jobs.reduce((a, j) => a + j.size, 0);
+    const startedAt = Date.now();
+    let working = facts.state;
+    let done = 0;
+    let bytesDone = 0;
 
-      for (const job of jobs) {
-        const status = reach.get(job.target.name);
-        if (status !== "ok") {
-          if (!skipped.some((s) => s.target === job.target.name)) {
-            skipped.push({
-              target: job.target.name,
-              why: status ?? "unreachable",
-            });
-          }
-          debug("check.skipped", {
-            unit: job.unit,
+    // Destinations that could not be reached, so the run can say what it did
+    // not do. Skipping in silence and then reporting "deep check finished"
+    // was a claim that nothing had been checked — indistinguishable from a
+    // check that never started.
+    const skipped: { readonly target: string; readonly why: Reachability }[] = [];
+
+    for (const job of jobs) {
+      const status = reach.get(job.target.name);
+      if (status !== "ok") {
+        if (!skipped.some((s) => s.target === job.target.name)) {
+          skipped.push({
             target: job.target.name,
-            reach: status,
+            why: status ?? "unreachable",
           });
-          done += 1;
-          bytesDone += job.size;
-          continue;
         }
-        // Estimated from measured throughput at this destination, so the bar
-        // works from the second check onwards on *any* folder rather than only
-        // on one that has been checked twice.
-        const prior = estimateMs(working, job.target.name, methodOf(mode), job.size);
-        const jobStarted = Date.now();
-        const base = {
+        debug("check.skipped", {
           unit: job.unit,
           target: job.target.name,
-          mode,
-          done,
-          total: jobs.length,
-          bytesDone,
-          bytesTotal,
-          startedAt,
-          jobStartedAt: jobStarted,
-          filesTotal: job.files,
-          unitBytes: job.size,
-          ...(prior !== undefined ? { priorMs: prior } : {}),
-        } as const;
-        setRunning({ ...base, filesSeen: 0 });
-        debug("check.start", {
-          mode,
-          unit: job.unit,
-          target: job.target.name,
-          bytes: job.size,
-          files: job.files,
-          estimateMs: prior ?? null,
+          reach: status,
         });
-        try {
-          const { scan, argv, items, targetFingerprint, exitCode } = await checkUnit(
-            facts.config,
-            job.unit,
-            job.target,
-            mode,
-            {
-              // Throttled: one render per 25 files keeps a large folder from
-              // driving the render loop instead of the check.
-              onFile: (seen) => {
-                if (seen % 25 === 0) setRunning({ ...base, filesSeen: seen });
-              },
-            },
-          );
-          const jobMs = Date.now() - jobStarted;
-          debug("check.done", {
-            mode,
-            unit: job.unit,
-            target: job.target.name,
-            ms: jobMs,
-            bytes: job.size,
-            outcome: scan.outcome,
-            nChanges: scan.nChanges,
-            // A rate only where one was actually achieved. A quick check reads
-            // no file contents, so dividing the folder's bytes by its elapsed
-            // time reported 90,353 MB/s — a number with no referent. Sub-second
-            // runs are excluded for the same reason: the divisor is noise.
-            ...(mode === "deep" && jobMs >= 1000
-              ? { readMBPerSec: Math.round(job.size / 1e6 / (jobMs / 1000)) }
-              : {}),
-          });
-          working = upsertScan(working, scan);
-          saveState(working);
-          // The itemized list is what the differences screen shows. rsync
-          // produced it during the check; discarding it would mean re-running
-          // the whole check to answer "which files?".
-          saveDiff(
-            buildDiff(job.unit, job.target.name, scan.method, items, {
-              ts: scan.ts,
-              wholeFolderMissing: scan.outcome === "missing",
-              source: scan.fingerprint,
-              target: targetFingerprint,
-            }),
-          );
-          appendHistory({
-            ts: scan.ts,
-            unit: job.unit,
-            target: job.target.name,
-            argv,
-            exitCode,
-          });
-          // Publish after every unit so the ledger fills in as it goes rather
-          // than staying blank until the whole run finishes.
-          facts.setState(working);
-          facts.setNow(Date.now());
-        } catch (e) {
-          // Explicit catch at the subprocess boundary; a swallowed rejection
-          // would leave the ledger showing stale state as if it were fresh.
-          debug("check.failed", {
-            unit: job.unit,
-            target: job.target.name,
-            ms: Date.now() - jobStarted,
-            error: (e as Error).message,
-          });
-          setBusy(`${job.unit} → ${job.target.name}: failed — ${(e as Error).message}`);
-        }
         done += 1;
         bytesDone += job.size;
+        continue;
       }
+      // Estimated from measured throughput at this destination, so the bar
+      // works from the second check onwards on *any* folder rather than only
+      // on one that has been checked twice.
+      const prior = estimateMs(working, job.target.name, methodOf(mode), job.size);
+      const jobStarted = Date.now();
+      const base = {
+        unit: job.unit,
+        target: job.target.name,
+        mode,
+        done,
+        total: jobs.length,
+        bytesDone,
+        bytesTotal,
+        startedAt,
+        jobStartedAt: jobStarted,
+        filesTotal: job.files,
+        unitBytes: job.size,
+        ...(prior !== undefined ? { priorMs: prior } : {}),
+      } as const;
+      setRunning({ ...base, filesSeen: 0 });
+      debug("check.start", {
+        mode,
+        unit: job.unit,
+        target: job.target.name,
+        bytes: job.size,
+        files: job.files,
+        estimateMs: prior ?? null,
+      });
+      try {
+        const { scan, argv, items, targetFingerprint, exitCode } = await checkUnit(
+          facts.config,
+          job.unit,
+          job.target,
+          mode,
+          {
+            // Throttled: one render per 25 files keeps a large folder from
+            // driving the render loop instead of the check.
+            onFile: (seen) => {
+              if (seen % 25 === 0) setRunning({ ...base, filesSeen: seen });
+            },
+          },
+        );
+        const jobMs = Date.now() - jobStarted;
+        debug("check.done", {
+          mode,
+          unit: job.unit,
+          target: job.target.name,
+          ms: jobMs,
+          bytes: job.size,
+          outcome: scan.outcome,
+          nChanges: scan.nChanges,
+          // A rate only where one was actually achieved. A quick check reads
+          // no file contents, so dividing the folder's bytes by its elapsed
+          // time reported 90,353 MB/s — a number with no referent. Sub-second
+          // runs are excluded for the same reason: the divisor is noise.
+          ...(mode === "deep" && jobMs >= 1000
+            ? { readMBPerSec: Math.round(job.size / 1e6 / (jobMs / 1000)) }
+            : {}),
+        });
+        working = upsertScan(working, scan);
+        saveState(working);
+        // The itemized list is what the differences screen shows. rsync
+        // produced it during the check; discarding it would mean re-running
+        // the whole check to answer "which files?".
+        saveDiff(
+          buildDiff(job.unit, job.target.name, scan.method, items, {
+            ts: scan.ts,
+            wholeFolderMissing: scan.outcome === "missing",
+            source: scan.fingerprint,
+            target: targetFingerprint,
+          }),
+        );
+        appendHistory({
+          ts: scan.ts,
+          unit: job.unit,
+          target: job.target.name,
+          argv,
+          exitCode,
+        });
+        // Publish after every unit so the ledger fills in as it goes rather
+        // than staying blank until the whole run finishes.
+        facts.setState(working);
+        facts.setNow(Date.now());
+      } catch (e) {
+        // Explicit catch at the subprocess boundary; a swallowed rejection
+        // would leave the ledger showing stale state as if it were fresh.
+        debug("check.failed", {
+          unit: job.unit,
+          target: job.target.name,
+          ms: Date.now() - jobStarted,
+          error: (e as Error).message,
+        });
+        setBusy(`${job.unit} → ${job.target.name}: failed — ${(e as Error).message}`);
+      }
+      done += 1;
+      bytesDone += job.size;
+    }
 
-      setRunning(null);
-      // A check can change what is at the target, and the source may have moved
-      // under us while it ran, so both facts are re-read once at the end.
-      facts.refresh();
-      // A run in which every destination was skipped checked nothing, and must
-      // not report otherwise.
-      const ran =
-        jobs.length -
-        skipped.reduce((n, s) => n + jobs.filter((j) => j.target.name === s.target).length, 0);
-      if (ran === 0 && skipped.length > 0) {
-        setBusy(
-          `nothing checked — ${skipped.map((s) => `${s.target} ${reachWord(s.why)}`).join(", ")}`,
-        );
-      } else if (skipped.length > 0) {
-        setBusy(
-          `${mode} check finished · ${ran} of ${jobs.length} · skipped ` +
-            skipped.map((s) => `${s.target} (${reachWord(s.why)})`).join(", "),
-        );
-      } else {
-        setBusy(
-          scope === "all"
-            ? `${mode} check finished · ${chosen.length} folders`
-            : `${mode} check finished · ${chosen[0]?.status.unit ?? ""}`,
-        );
-      }
-      facts.setNow(Date.now());
-      // A skip needs longer on screen than a success: it is the message the
-      // user has to read and act on.
-      setTimeout(() => setBusy(null), skipped.length > 0 ? 8000 : 2500);
-    },
-    // `facts` is rebuilt by the caller on every render — its members are the
-    // whole of the world the closure reads — and `running` is this hook's own
-    // state. Both change what a run will do, so both must re-make the callback.
-    [facts, running],
-  );
+    setRunning(null);
+    // A check can change what is at the target, and the source may have moved
+    // under us while it ran, so both facts are re-read once at the end.
+    facts.refresh();
+    // A run in which every destination was skipped checked nothing, and must
+    // not report otherwise.
+    const ran =
+      jobs.length -
+      skipped.reduce((n, s) => n + jobs.filter((j) => j.target.name === s.target).length, 0);
+    if (ran === 0 && skipped.length > 0) {
+      setBusy(
+        `nothing checked — ${skipped.map((s) => `${s.target} ${reachWord(s.why)}`).join(", ")}`,
+      );
+    } else if (skipped.length > 0) {
+      setBusy(
+        `${mode} check finished · ${ran} of ${jobs.length} · skipped ` +
+          skipped.map((s) => `${s.target} (${reachWord(s.why)})`).join(", "),
+      );
+    } else {
+      setBusy(
+        scope === "all"
+          ? `${mode} check finished · ${chosen.length} folders`
+          : `${mode} check finished · ${chosen[0]?.status.unit ?? ""}`,
+      );
+    }
+    facts.setNow(Date.now());
+    // A skip needs longer on screen than a success: it is the message the
+    // user has to read and act on.
+    setTimeout(() => setBusy(null), skipped.length > 0 ? 8000 : 2500);
+  };
 
   return { running, busy, runCheck };
 }

--- a/src/tui/useJob.ts
+++ b/src/tui/useJob.ts
@@ -1,0 +1,253 @@
+import { useCallback, useState } from "react";
+import type { Config } from "../config.ts";
+import { buildDiff, saveDiff } from "../diff.ts";
+import type { Fingerprint } from "../fingerprint.ts";
+import { debug } from "../log.ts";
+import { allReachability, checkUnit, methodOf, type Reachability } from "../scan.ts";
+import { appendHistory, estimateMs, type State, saveState, upsertScan } from "../state.ts";
+import { reachWord } from "../status.ts";
+import type { Row } from "./Ledger.tsx";
+import type { RunProgress } from "./Progress.tsx";
+
+/**
+ * Running a check: the state of the work itself, separated from the screens.
+ *
+ * `App` used to hold the whole orchestration — the job list, the bar, the
+ * per-destination skips, the state writes — inside a 760-line component
+ * alongside its keyboard handling and render tree. The job is self-contained
+ * except for the facts it reads (rows, cached scan) and the effects it has
+ * (state, the ledger's busy line, a notification when a key is refused), so
+ * those are the only things it takes and the only things it returns.
+ */
+
+/** What the caller knows about the world, so the job can plan against it. */
+export interface JobFacts {
+  readonly config: Config;
+  /** The rows currently on screen, in the order they appear. */
+  readonly rows: Row[];
+  /** Which row the cursor is on, already clamped to the visible range. */
+  readonly clampedSelection: number;
+  readonly state: State;
+  /** Cached fingerprints and reachability, or null before the first scan. */
+  readonly scan: {
+    readonly fingerprints: ReadonlyMap<string, Fingerprint>;
+    readonly reach: ReadonlyMap<string, Reachability>;
+  } | null;
+  /** Re-read fingerprints and reachability after the run has changed things. */
+  readonly refresh: () => void;
+  /** Show a short refusal message, e.g. when a key arrives while a job runs. */
+  readonly notify: (text: string) => void;
+  readonly setNow: React.Dispatch<React.SetStateAction<number>>;
+  readonly setState: React.Dispatch<React.SetStateAction<State>>;
+}
+
+export interface Job {
+  /** The run in flight, for the row the cursor may have left. */
+  readonly running: RunProgress | null;
+  /** The transient status line under the ledger, or null when idle. */
+  readonly busy: string | null;
+  readonly runCheck: (mode: "quick" | "deep", scope: "selected" | "all") => Promise<void>;
+}
+
+export function useJob(facts: JobFacts): Job {
+  const [busy, setBusy] = useState<string | null>(null);
+  /**
+   * What is being checked right now.
+   *
+   * Held separately from `busy` — which is a transient message — so the work
+   * stays visible on the row it belongs to even after the cursor moves away.
+   */
+  const [running, setRunning] = useState<RunProgress | null>(null);
+
+  const runCheck = useCallback(
+    async (mode: "quick" | "deep", scope: "selected" | "all") => {
+      if (running !== null) {
+        facts.notify(
+          `[${mode === "deep" ? "d" : "q"}] ignored — the ${running.mode} check on ` +
+            `${running.unit} is still running`,
+        );
+        return;
+      }
+      const chosen =
+        scope === "all"
+          ? facts.rows
+          : facts.rows.slice(facts.clampedSelection, facts.clampedSelection + 1);
+      if (chosen.length === 0) return;
+
+      const reach = facts.scan?.reach ?? (await allReachability(facts.config));
+      const jobs = chosen.flatMap((row) =>
+        facts.config.targets.map((target) => ({
+          unit: row.status.unit,
+          target,
+          size: row.size,
+          files: row.files ?? 0,
+        })),
+      );
+      // The bar fills by bytes: a 78 gb folder and a 442 mb one take wildly
+      // different times, so counting folders equally would make it lie.
+      const bytesTotal = jobs.reduce((a, j) => a + j.size, 0);
+      const startedAt = Date.now();
+      let working = facts.state;
+      let done = 0;
+      let bytesDone = 0;
+
+      // Destinations that could not be reached, so the run can say what it did
+      // not do. Skipping in silence and then reporting "deep check finished"
+      // was a claim that nothing had been checked — indistinguishable from a
+      // check that never started.
+      const skipped: { readonly target: string; readonly why: Reachability }[] = [];
+
+      for (const job of jobs) {
+        const status = reach.get(job.target.name);
+        if (status !== "ok") {
+          if (!skipped.some((s) => s.target === job.target.name)) {
+            skipped.push({
+              target: job.target.name,
+              why: status ?? "unreachable",
+            });
+          }
+          debug("check.skipped", {
+            unit: job.unit,
+            target: job.target.name,
+            reach: status,
+          });
+          done += 1;
+          bytesDone += job.size;
+          continue;
+        }
+        // Estimated from measured throughput at this destination, so the bar
+        // works from the second check onwards on *any* folder rather than only
+        // on one that has been checked twice.
+        const prior = estimateMs(working, job.target.name, methodOf(mode), job.size);
+        const jobStarted = Date.now();
+        const base = {
+          unit: job.unit,
+          target: job.target.name,
+          mode,
+          done,
+          total: jobs.length,
+          bytesDone,
+          bytesTotal,
+          startedAt,
+          jobStartedAt: jobStarted,
+          filesTotal: job.files,
+          unitBytes: job.size,
+          ...(prior !== undefined ? { priorMs: prior } : {}),
+        } as const;
+        setRunning({ ...base, filesSeen: 0 });
+        debug("check.start", {
+          mode,
+          unit: job.unit,
+          target: job.target.name,
+          bytes: job.size,
+          files: job.files,
+          estimateMs: prior ?? null,
+        });
+        try {
+          const { scan, argv, items, targetFingerprint, exitCode } = await checkUnit(
+            facts.config,
+            job.unit,
+            job.target,
+            mode,
+            {
+              // Throttled: one render per 25 files keeps a large folder from
+              // driving the render loop instead of the check.
+              onFile: (seen) => {
+                if (seen % 25 === 0) setRunning({ ...base, filesSeen: seen });
+              },
+            },
+          );
+          const jobMs = Date.now() - jobStarted;
+          debug("check.done", {
+            mode,
+            unit: job.unit,
+            target: job.target.name,
+            ms: jobMs,
+            bytes: job.size,
+            outcome: scan.outcome,
+            nChanges: scan.nChanges,
+            // A rate only where one was actually achieved. A quick check reads
+            // no file contents, so dividing the folder's bytes by its elapsed
+            // time reported 90,353 MB/s — a number with no referent. Sub-second
+            // runs are excluded for the same reason: the divisor is noise.
+            ...(mode === "deep" && jobMs >= 1000
+              ? { readMBPerSec: Math.round(job.size / 1e6 / (jobMs / 1000)) }
+              : {}),
+          });
+          working = upsertScan(working, scan);
+          saveState(working);
+          // The itemized list is what the differences screen shows. rsync
+          // produced it during the check; discarding it would mean re-running
+          // the whole check to answer "which files?".
+          saveDiff(
+            buildDiff(job.unit, job.target.name, scan.method, items, {
+              ts: scan.ts,
+              wholeFolderMissing: scan.outcome === "missing",
+              source: scan.fingerprint,
+              target: targetFingerprint,
+            }),
+          );
+          appendHistory({
+            ts: scan.ts,
+            unit: job.unit,
+            target: job.target.name,
+            argv,
+            exitCode,
+          });
+          // Publish after every unit so the ledger fills in as it goes rather
+          // than staying blank until the whole run finishes.
+          facts.setState(working);
+          facts.setNow(Date.now());
+        } catch (e) {
+          // Explicit catch at the subprocess boundary; a swallowed rejection
+          // would leave the ledger showing stale state as if it were fresh.
+          debug("check.failed", {
+            unit: job.unit,
+            target: job.target.name,
+            ms: Date.now() - jobStarted,
+            error: (e as Error).message,
+          });
+          setBusy(`${job.unit} → ${job.target.name}: failed — ${(e as Error).message}`);
+        }
+        done += 1;
+        bytesDone += job.size;
+      }
+
+      setRunning(null);
+      // A check can change what is at the target, and the source may have moved
+      // under us while it ran, so both facts are re-read once at the end.
+      facts.refresh();
+      // A run in which every destination was skipped checked nothing, and must
+      // not report otherwise.
+      const ran =
+        jobs.length -
+        skipped.reduce((n, s) => n + jobs.filter((j) => j.target.name === s.target).length, 0);
+      if (ran === 0 && skipped.length > 0) {
+        setBusy(
+          `nothing checked — ${skipped.map((s) => `${s.target} ${reachWord(s.why)}`).join(", ")}`,
+        );
+      } else if (skipped.length > 0) {
+        setBusy(
+          `${mode} check finished · ${ran} of ${jobs.length} · skipped ` +
+            skipped.map((s) => `${s.target} (${reachWord(s.why)})`).join(", "),
+        );
+      } else {
+        setBusy(
+          scope === "all"
+            ? `${mode} check finished · ${chosen.length} folders`
+            : `${mode} check finished · ${chosen[0]?.status.unit ?? ""}`,
+        );
+      }
+      facts.setNow(Date.now());
+      // A skip needs longer on screen than a success: it is the message the
+      // user has to read and act on.
+      setTimeout(() => setBusy(null), skipped.length > 0 ? 8000 : 2500);
+    },
+    // `facts` is rebuilt by the caller on every render — its members are the
+    // whole of the world the closure reads — and `running` is this hook's own
+    // state. Both change what a run will do, so both must re-make the callback.
+    [facts, running],
+  );
+
+  return { running, busy, runCheck };
+}

--- a/src/tui/useKeys.ts
+++ b/src/tui/useKeys.ts
@@ -1,0 +1,85 @@
+import { useInput } from "ink";
+
+/**
+ * The ledger's keyboard, as a state machine rather than a cascade of guards.
+ *
+ * Every key goes through the same decision: which screen owns the keyboard
+ * right now? `App` used to answer that with a chain of early returns woven
+ * through its key handler; the chain is the behaviour, and it is exactly this
+ * code, moved out so the component can stay a composition of screens.
+ *
+ * The order of the guards is part of the contract: ctrl-c always comes first,
+ * the help screen swallows every key, and a screen that owns the keyboard
+ * (diff, plan, setup, the confirm and job pages) swallows it entirely —
+ * `App`'s handler must not act on a key that screen has not decided with.
+ */
+
+/** Which screen owns the keyboard. */
+export type KeyMode =
+  | "ledger"
+  | "help"
+  | "evidence"
+  /** Diff, plan, setup, confirm and job: the keyboard belongs to that screen. */
+  | "inert";
+
+/** What the ledger screen can do with a key. */
+export interface LedgerKeys {
+  readonly up: () => void;
+  readonly down: () => void;
+  readonly quick: () => void;
+  readonly quickAll: () => void;
+  readonly deep: () => void;
+  readonly deepAll: () => void;
+  readonly refresh: () => void;
+  readonly cycleFilter: () => void;
+  readonly evidence: () => void;
+  readonly openDiff: () => void;
+  readonly openPlan: () => void;
+  readonly startSync: () => void;
+  readonly setup: () => void;
+  readonly help: () => void;
+}
+
+export interface KeyActions {
+  /**
+   * ctrl-c, before any other screen sees it. The caller decides whether it
+   * exits right away: while a transfer is running, the first press is the job
+   * screen's to act on (it cancels rsync), and only a second press exits.
+   */
+  readonly controlC: () => void;
+  /** Any key closes the help screen. */
+  readonly closeHelp: () => void;
+  readonly closeEvidence: () => void;
+  readonly ledger: LedgerKeys;
+}
+
+export function useKeys(mode: KeyMode, actions: KeyActions): void {
+  useInput((input, key) => {
+    if (key.ctrl && input === "c") return actions.controlC();
+    if (mode === "help") {
+      actions.closeHelp();
+      return;
+    }
+    if (mode === "evidence") {
+      if (key.escape || input === "e") actions.closeEvidence();
+      return;
+    }
+    if (mode === "inert") return; // The owning screen has the keyboard.
+
+    const k = actions.ledger;
+    if (key.upArrow || input === "k") k.up();
+    else if (key.downArrow || input === "j") k.down();
+    else if (input === "q") k.quick();
+    else if (input === "Q") k.quickAll();
+    else if (input === "d") k.deep();
+    else if (input === "D") k.deepAll();
+    else if (input === "r") k.refresh();
+    else if (input === "f") k.cycleFilter();
+    else if (input === "e") k.evidence();
+    else if (key.return) k.openDiff();
+    else if (input === "p") k.openPlan();
+    else if (input === "s") k.startSync();
+    else if (input === ",") k.setup();
+    else if (input === "?") k.help();
+  });
+}


### PR DESCRIPTION
`App` held the whole check orchestration (job list, byte-based progress, per-destination skip accounting, state and history writes) alongside its keyboard handling and render tree in one ~760-line component.

- **`useJob`** — the check is self-contained except for the facts it reads (rows, cached scan) and the effects it has (state, the ledger's busy line, a refusal notice); those are the only things the hook takes and returns. `runCheck` is moved verbatim, comments included — including the per-job start time and the exit code rsync returned.
- **`useKeys`** — the keyboard is a state machine: which screen owns it (`help` / `evidence` / `inert` / `ledger`), with the guard order preserved exactly — ctrl-c always comes first, help swallows every key, and an owning screen swallows the keyboard entirely.
- **The ctrl-c decision stays in `App`**, because it is the app's: while a transfer is running the first press is left to the job screen to cancel, and only a second press exits — `useKeys` merely forwards the key it always saw first.

What remains in `App` is composition: the state the screens share, the overlay screens, and the window title. Refactor only; behaviour unchanged.