### PR TITLE
feat: rotate history.jsonl at 5 MB, keeping one previous

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -6,6 +6,7 @@ import {
   openSync,
   readFileSync,
   renameSync,
+  statSync,
   writeSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
@@ -275,7 +276,34 @@ export interface HistoryEntry {
 /** Append-only, and separate from state so history writes can never endanger it. */
 export function appendHistory(entry: HistoryEntry, file: string = historyFile()): void {
   mkdirSync(dirname(file), { recursive: true });
+  rotateHistory(file);
   appendFileSync(file, JSON.stringify(entry) + "\n", "utf8");
+}
+
+/**
+ * Rotate at this size, keeping one previous file.
+ *
+ * The same discipline as the debug log: the plain-file format is the point —
+ * a record you can cat, grep and back up — and a single unbounded file
+ * eventually stops being that. Five megabytes is years of daily checks across
+ * a dozen folders and a couple of destinations, and still reads in one pass.
+ * The rotated file is `history.jsonl.1`; deleting it costs nothing, since it
+ * is a record of what ran, not of what is verified.
+ */
+export const MAX_HISTORY_BYTES = 5 * 1024 * 1024;
+
+/** Rolls the history over when it gets large, keeping exactly one previous file. */
+function rotateHistory(file: string): void {
+  try {
+    if (statSync(file).size < MAX_HISTORY_BYTES) return;
+  } catch {
+    return; // No file yet, nothing to rotate.
+  }
+  try {
+    renameSync(file, `${file}.1`);
+  } catch {
+    // A failed rotation must not stop the record being written.
+  }
 }
 
 /**

--- a/src/state.ts
+++ b/src/state.ts
@@ -292,7 +292,17 @@ export function appendHistory(entry: HistoryEntry, file: string = historyFile())
  */
 export const MAX_HISTORY_BYTES = 5 * 1024 * 1024;
 
-/** Rolls the history over when it gets large, keeping exactly one previous file. */
+/**
+ * Rolls the history over when it gets large, keeping exactly one previous file.
+ *
+ * Checked before the append, against the size the file already has, so the
+ * cap is a floor rather than a ceiling: the entry that crosses 5 MB is
+ * written to the file that crossed it, and the *next* append is the one that
+ * rotates. Measuring the entry first to keep the file strictly under the cap
+ * would buy a stricter bound on a file whose whole point is that it is
+ * readable in one pass, at the cost of a size the caller has to compute
+ * twice.
+ */
 function rotateHistory(file: string): void {
   try {
     if (statSync(file).size < MAX_HISTORY_BYTES) return;

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Fingerprint } from "../src/fingerprint.ts";
 import {
@@ -9,6 +9,7 @@ import {
   findScan,
   latestScan,
   loadState,
+  MAX_HISTORY_BYTES,
   type Scan,
   type State,
   saveState,
@@ -227,6 +228,23 @@ describe("history", () => {
     const argv = ["-aAXc", "-n", "-i", "/src/", "/dst/"];
     appendHistory({ ts: 1, unit: "u", target: "nas", argv, exitCode: 0 }, file);
     expect(JSON.parse(readFileSync(file, "utf8").trim()).argv).toEqual(argv);
+  });
+
+  test("it rotates once it passes the cap, keeping one previous file", () => {
+    // The record is append-only by design; the rotation is what keeps
+    // append-only from growing without bound in a directory nobody watches.
+    const file = join(dir, "history.jsonl");
+    writeFileSync(file, "x".repeat(MAX_HISTORY_BYTES + 1));
+    appendHistory({ ts: 1, unit: "u", target: "nas", argv: ["-a"], exitCode: 0 }, file);
+    expect(existsSync(`${file}.1`), "previous history kept").toBe(true);
+    expect(readFileSync(file, "utf8")).toContain('"unit":"u"');
+    expect(statSync(file).size).toBeLessThan(MAX_HISTORY_BYTES);
+  });
+
+  test("a fresh history does not rotate", () => {
+    const file = join(dir, "history.jsonl");
+    appendHistory({ ts: 1, unit: "u", target: "nas", argv: ["-a"], exitCode: 0 }, file);
+    expect(existsSync(`${file}.1`)).toBe(false);
   });
 });
 


### PR DESCRIPTION
The record was append-only with no bound, while the debug log already rotated at 2 MB. The plain-file format is the point, so rotation keeps it:

- when an append would push `history.jsonl` past **5 MB**, the current file is renamed to `history.jsonl.1` (replacing an older rotation) and a fresh one starts
- the check happens on the writer's path, not a background task, so there is nothing to race the app over the file
- a failed rotation must not stop the record being written, so it is caught and dropped
- the 2 MB cap on the debug log is unchanged

5 MB is years of daily checks (history is written at most a handful of times a day), and the previous file is still a plain file readable with `cat`/`grep`/`diff`.

Tests in `test/state.test.ts`: rotation at the cap, and the fresh-start case. No interaction with the scan validation that landed on main — `validateScan` reads `state.json`, which rotation never touches.