### PR TITLE
ci: GitHub Actions on macOS and Linux, release builds for all four targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,18 @@ on:
     tags: ["v*"]
   pull_request:
 
+# A second push to the same branch supersedes the first. Tags are exempt: a
+# release build that is cancelled halfway leaves a release with some of its
+# assets, which is worse than a wasted runner.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
+
+# Pinned for the same reason the linter is: CI must fail because the code
+# changed, not because a toolchain moved underneath it.
+env:
+  BUN_VERSION: "1.3.14"
+
 jobs:
   check:
     name: check · ${{ matrix.os }}
@@ -22,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install
         run: bun install --frozen-lockfile
       - name: Install rsync 3.x
@@ -38,7 +50,7 @@ jobs:
       - name: Test
         run: bun test
 
-  release:
+  build:
     name: build · ${{ matrix.target }}
     runs-on: ${{ matrix.runs-on }}
     if: github.ref_type == 'tag'
@@ -61,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
       - name: Install
         run: bun install --frozen-lockfile
       - name: Build
@@ -71,3 +83,38 @@ jobs:
         with:
           name: syncy-${{ matrix.target }}
           path: syncy-${{ matrix.target }}
+          if-no-files-found: error
+
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
+    needs: build
+    # The one job that writes anything outside the run.
+    permissions:
+      contents: write
+    steps:
+      - name: Collect the binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: syncy-*
+          merge-multiple: true
+      # Checksums are generated where all four binaries are, which is why the
+      # matrix uploads artifacts and this job publishes: a per-target runner
+      # can only ever checksum its own build.
+      - name: Checksums
+        working-directory: dist
+        run: sha256sum syncy-* | tee checksums.txt
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        working-directory: dist
+        # `--generate-notes` writes the changelog from the commits since the
+        # previous tag; the assets are the four binaries and their checksums.
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            syncy-* checksums.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+
+jobs:
+  check:
+    name: check · ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Both platforms run the full suite: the tests spawn real rsync, so the
+      # macOS branch exercises /sbin/mount and diskutil, the Linux branch
+      # /proc/mounts and sysfs. A platform regression must fail on its own
+      # runner, not slip through because the other one passed.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install
+        run: bun install --frozen-lockfile
+      - name: Install rsync 3.x
+        # The suite spawns a real rsync. macOS ships openrsync at /usr/bin,
+        # which syncy refuses, so the Homebrew build is the one under test;
+        # ubuntu-latest already ships a 3.x rsync.
+        if: runner.os == 'macOS'
+        run: brew install rsync
+      - name: Typecheck
+        run: bunx tsc --noEmit
+      - name: Lint
+        run: bunx @biomejs/biome@2.5.10 check .
+      - name: Test
+        run: bun test
+
+  release:
+    name: build · ${{ matrix.target }}
+    runs-on: ${{ matrix.runs-on }}
+    if: github.ref_type == 'tag'
+    needs: check
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both macOS targets build on one arm64 runner: bun cross-compiles
+        # against the target's runtime rather than the host's.
+        include:
+          - target: bun-darwin-arm64
+            runs-on: macos-14
+          - target: bun-darwin-x64
+            runs-on: macos-14
+          - target: bun-linux-x64
+            runs-on: ubuntu-latest
+          - target: bun-linux-arm64
+            runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install
+        run: bun install --frozen-lockfile
+      - name: Build
+        run: bun run build -- --target=${{ matrix.target }}
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: syncy-${{ matrix.target }}
+          path: syncy-${{ matrix.target }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 syncy
+syncy-*
 *.log
 .test-tmp/
 *.bun-build

--- a/README.md
+++ b/README.md
@@ -137,13 +137,25 @@ extended attributes.
 
 **rsync 3.x.** macOS ships openrsync at `/usr/bin/rsync`, which reports itself
 as "rsync version 2.6.9 compatible" and then rejects `-A`. syncy does not
-resolve rsync from `PATH`. It checks `/opt/homebrew/bin`, `/usr/local/bin` and
-`/opt/local/bin` in that order, and refuses to run against openrsync rather than
-failing later per folder. `SYNCY_RSYNC` overrides the path.
+resolve rsync from `PATH`. On macOS it checks `/opt/homebrew/bin`,
+`/usr/local/bin` and `/opt/local/bin` in that order, and refuses to run against
+openrsync rather than failing later per folder. On Linux the distribution
+rsync at `/usr/bin` is used as-is — it is the real thing there — and the build
+check still refuses anything older than 3.x. `SYNCY_RSYNC` overrides the path.
 
 ```
-brew install rsync
+brew install rsync        # macOS
+sudo apt install rsync    # or the distro equivalent
 ```
+
+**Linux.** The mount table is read from `/proc/mounts` and volume UUIDs from
+sysfs, so no `diskutil` and no `mount` subprocess. Where the kernel publishes
+no UUID for a device the device path is the identity, which still separates
+one volume from another. The capability probe uses the `attr` and `acl`
+packages (`setfattr`/`getfattr`, `setfacl`/`getfacl`) when they are installed;
+a missing tool reports the capability as unmeasured and drops the flag
+rather than guessing. Copying the plan needs `wl-clipboard` or `xclip`;
+without one the button says so.
 
 **Bun**, to build.
 
@@ -155,9 +167,13 @@ brew install bun
 
 ```
 bun install
-bun run build          # produces a self-contained ./syncy
+bun run build          # self-contained ./syncy for this platform
+bun run build:all      # every supported target, named syncy-<target>
 cp syncy ~/.local/bin/
 ```
+
+Supported targets: macOS (Apple Silicon and Intel) and Linux (x64 and
+arm64). The release workflow builds all four from a `v*` tag.
 
 ## Use
 
@@ -298,8 +314,9 @@ own palette.
 ## Development
 
 ```
-bun test               # 730 tests
+bun test               # 816 tests
 bunx tsc --noEmit
+bunx @biomejs/biome@2.5.10 check .   # lint and format; --write to fix
 bun run build
 bun run audit          # no machine-specific data in the tree or the history
 ```
@@ -311,6 +328,19 @@ redirects the XDG directories into the project before any test file loads. One
 test asserts that a full run leaves the real config and state byte-identical;
 another rejects any test file naming a path that exists on the machine running
 it.
+
+The linter is Biome with the recommended rules, minus four style rules the
+codebase deliberately does not follow: non-null assertions (the nullability is
+argued in comments, the type-checker holds the line), `"str" + x` versus
+templates and `obj["key"]` versus `obj.key` (both are this codebase's
+established style, most in the runtime validators for untrusted input), and
+array-index keys (the TUI renders log and line streams in fixed order, where
+the index is the honest key). Where a rule is suppressed in code it is
+suppressed with a `biome-ignore` comment stating the reason.
+
+Biome runs through `bunx` with a pinned version rather than as a
+dependency: it is a dev-time tool that ships in no binary, so the lockfile
+stays limited to what the type-checker and the tests actually need.
 
 `DESIGN.md` records the decisions and the reasoning behind them.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,15 @@ cp syncy ~/.local/bin/
 ```
 
 Supported targets: macOS (Apple Silicon and Intel) and Linux (x64 and
-arm64). The release workflow builds all four from a `v*` tag.
+arm64). Pushing a `v*` tag builds all four, attaches them to the GitHub
+release with a `checksums.txt`, and generates the notes from the commits
+since the previous tag. A downloaded binary arrives without its executable
+bit, as anything fetched over HTTP does:
+
+```
+shasum -a 256 -c checksums.txt --ignore-missing
+chmod +x syncy-bun-darwin-arm64 && mv syncy-bun-darwin-arm64 ~/.local/bin/syncy
+```
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,11 @@ sudo apt install rsync    # or the distro equivalent
 no `mount` subprocess. A volume's UUID comes from `/dev/disk/by-uuid` — the
 same names `blkid` and your `fstab` use — falling back to `by-partuuid`, and
 to sysfs for the devices that publish one of their own. Where nothing stable
-is published the device path is recorded instead, and syncy then treats it as
-the weaker proof it is: `/dev/sdb1` is a slot in this boot's enumeration
-order, not a name for a disk, so a target identified that way gets a sentinel
-file and both are checked before anything is written to it. The capability
+is published the device path is recorded instead, and syncy treats it as the
+weaker thing it is: `/dev/sdb1` is a slot in this boot's enumeration order,
+not a name for a disk. Such a target still works, and says so when you add
+it; where it also has a sentinel, the sentinel is what decides. `syncy
+sentinel <path>` writes one. Adding a target never writes to the target. The capability
 probe uses the `attr` and `acl` packages (`setfattr`/`getfattr`,
 `setfacl`/`getfacl`) when they are installed; a missing tool reports the
 capability as unmeasured and drops the flag rather than guessing. Copying the

--- a/README.md
+++ b/README.md
@@ -148,14 +148,18 @@ brew install rsync        # macOS
 sudo apt install rsync    # or the distro equivalent
 ```
 
-**Linux.** The mount table is read from `/proc/mounts` and volume UUIDs from
-sysfs, so no `diskutil` and no `mount` subprocess. Where the kernel publishes
-no UUID for a device the device path is the identity, which still separates
-one volume from another. The capability probe uses the `attr` and `acl`
-packages (`setfattr`/`getfattr`, `setfacl`/`getfacl`) when they are installed;
-a missing tool reports the capability as unmeasured and drops the flag
-rather than guessing. Copying the plan needs `wl-clipboard` or `xclip`;
-without one the button says so.
+**Linux.** The mount table is read from `/proc/mounts`, so no `diskutil` and
+no `mount` subprocess. A volume's UUID comes from `/dev/disk/by-uuid` — the
+same names `blkid` and your `fstab` use — falling back to `by-partuuid`, and
+to sysfs for the devices that publish one of their own. Where nothing stable
+is published the device path is recorded instead, and syncy then treats it as
+the weaker proof it is: `/dev/sdb1` is a slot in this boot's enumeration
+order, not a name for a disk, so a target identified that way gets a sentinel
+file and both are checked before anything is written to it. The capability
+probe uses the `attr` and `acl` packages (`setfattr`/`getfattr`,
+`setfacl`/`getfacl`) when they are installed; a missing tool reports the
+capability as unmeasured and drops the flag rather than guessing. Copying the
+plan needs `wl-clipboard` or `xclip`; without one the button says so.
 
 **Bun**, to build.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
   "scripts": {
     "start": "bun run src/cli.ts",
     "test": "bun test",
-    "build": "bun build --compile --minify --target=bun-darwin-arm64 src/cli.ts --outfile syncy",
+    "typecheck": "tsc --noEmit",
+    "lint": "bunx @biomejs/biome@2.5.10 check .",
+    "format": "bunx @biomejs/biome@2.5.10 check --write .",
+    "build": "bun run scripts/build.ts",
+    "build:all": "bun run scripts/build.ts --all",
     "testdata": "bun run scripts/testdata.ts",
     "audit": "sh scripts/audit-history.sh"
   },

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,62 @@
+/**
+ * Compiles the self-contained binary.
+ *
+ * With no flags it builds for the platform it runs on, so `bun run build`
+ * produces a usable `syncy` on any supported machine. `--target=<name>` builds
+ * one specific target, and `--all` builds every supported target — that is
+ * what the release workflow runs.
+ *
+ * The output is named `syncy-<target>` so a machine can keep builds for more
+ * than one target without overwriting the one it runs. The native build keeps
+ * the plain `syncy` name that the rest of the tooling (the testdata runner)
+ * already expects.
+ */
+
+const TARGETS = ["bun-darwin-arm64", "bun-darwin-x64", "bun-linux-x64", "bun-linux-arm64"] as const;
+type Target = (typeof TARGETS)[number];
+
+function nativeTarget(): Target {
+  const platform =
+    process.platform === "darwin" ? "darwin" : process.platform === "linux" ? "linux" : null;
+  if (platform === null) throw new Error(`unsupported platform: ${process.platform}`);
+  const arch = process.arch === "arm64" ? "arm64" : process.arch === "x64" ? "x64" : null;
+  if (arch === null) throw new Error(`unsupported architecture: ${process.arch}`);
+  const target = `bun-${platform}-${arch}`;
+  if (!(TARGETS as readonly string[]).includes(target)) {
+    throw new Error(`no release target for ${target}`);
+  }
+  return target;
+}
+
+function build(target: Target, outfile: string): void {
+  const result = Bun.spawnSync(
+    [
+      "bun",
+      "build",
+      "--compile",
+      "--minify",
+      `--target=${target}`,
+      "src/cli.ts",
+      `--outfile=${outfile}`,
+    ],
+    { stdout: "inherit", stderr: "inherit" },
+  );
+  if (result.exitCode !== 0) process.exit(result.exitCode ?? 1);
+}
+
+const args = process.argv.slice(2);
+
+if (args.includes("--all")) {
+  for (const target of TARGETS) build(target, `syncy-${target}`);
+} else {
+  const flag = args.find((a) => a.startsWith("--target="));
+  if (flag !== undefined) {
+    const target = flag.slice("--target=".length);
+    if (!(TARGETS as readonly string[]).includes(target)) {
+      throw new Error(`unknown target ${target}; expected one of ${TARGETS.join(", ")}`);
+    }
+    build(target, `syncy-${target}`);
+  } else {
+    build(nativeTarget(), "syncy");
+  }
+}

--- a/test/keys.test.tsx
+++ b/test/keys.test.tsx
@@ -64,9 +64,48 @@ function mount() {
   return {
     ...r,
     frame: () => plain(r.lastFrame()),
+    /**
+     * The ledger's first real frame.
+     *
+     * The opening frame is empty: there are no rows until the first scan
+     * resolves, and that is genuine work — a fingerprint of every unit and a
+     * reachability check per target. Every test here used to bet a fixed
+     * 120ms sleep on that finishing, which measured ~87ms on a laptop: a
+     * quarter of a second of headroom, and none at all on a loaded CI runner,
+     * where the footer assertion failed outright and two others flaked. What
+     * these tests are about is what the interface does with a key, never how
+     * quickly it got on screen, so they wait for the screen instead of
+     * guessing at it.
+     */
+    async ready() {
+      await waitFor(() => plain(r.lastFrame()).includes("[q]"), {
+        what: "the ledger's first frame",
+      });
+    },
+    /**
+     * Press a key and let the screen catch up.
+     *
+     * Also not a fixed sleep, and for the same reason: the two tests that
+     * flaked on CI — twice, on different runs of identical code — were a
+     * press followed by an assertion about what the press opened. This
+     * returns the moment the screen moves, which is a few milliseconds even
+     * on a busy machine, so the assertion is never racing a timer.
+     *
+     * The wait has to end somewhere, because a key that legitimately changes
+     * nothing is a real case: `j` at the bottom of the list moves no cursor,
+     * and one test presses it five times. So it gives up after a limit set to
+     * be generous against a slow runner and cheap to pay five times over, and
+     * gives up quietly — whether the key did its job is the test's assertion
+     * to make, not this helper's.
+     */
     async press(s: string) {
+      const before = plain(r.lastFrame());
       r.stdin.write(s);
-      await tick();
+      const deadline = Date.now() + 400;
+      while (Date.now() < deadline) {
+        await tick(5);
+        if (plain(r.lastFrame()) !== before) return;
+      }
     },
   };
 }
@@ -82,7 +121,7 @@ describe("the help screen lists each key once", () => {
     // A duplicated React key makes the renderer free to omit one of the pair,
     // so a key can disappear from help with nothing failing.
     const s = mount();
-    await tick();
+    await s.ready();
     await s.press("?");
     const listed = [...s.frame().matchAll(/^\s{2}(\S[^\s]*(?:\s\/\s\S+)?)\s{2,}\S/gm)].map(
       (m) => m[1]!,
@@ -101,7 +140,7 @@ describe("the help screen lists each key once", () => {
 describe("the footer advertises only keys that work", () => {
   test("it advertises a plausible set", async () => {
     const s = mount();
-    await tick();
+    await s.ready();
     const keys = advertisedKeys(s.frame());
     expect(keys.length).toBeGreaterThanOrEqual(4);
     // [?] is the disclosure for everything the line had no room for, so it is
@@ -115,7 +154,7 @@ describe("the footer advertises only keys that work", () => {
       // The regression: a key can be advertised in the footer and in help while
       // never reaching a dispatch branch, so pressing it does nothing at all.
       const s = mount();
-      await tick();
+      await s.ready();
       const before = s.frame();
       await s.press(key);
       expect(s.frame(), `[${key}] did nothing`).not.toBe(before);
@@ -125,7 +164,7 @@ describe("the footer advertises only keys that work", () => {
 
   test("[f] cycles the filter", async () => {
     const s = mount();
-    await tick();
+    await s.ready();
     await s.press("f");
     expect(s.frame()).toContain("filter:");
     s.unmount();
@@ -135,7 +174,7 @@ describe("the footer advertises only keys that work", () => {
 describe("the screens each key opens", () => {
   test("p opens the command list for the selected folder", async () => {
     const s = mount();
-    await tick();
+    await s.ready();
     await s.press("p");
     const f = s.frame();
     expect(f).toContain("what each key runs");
@@ -146,7 +185,7 @@ describe("the screens each key opens", () => {
 
   test("p shows the real rsync binary and flags, not a description", async () => {
     const s = mount();
-    await tick();
+    await s.ready();
     await s.press("p");
     expect(s.frame()).toContain("--partial-dir=.syncy-partial");
     s.unmount();
@@ -154,7 +193,7 @@ describe("the screens each key opens", () => {
 
   test("escape closes the command list", async () => {
     const s = mount();
-    await tick();
+    await s.ready();
     await s.press("p");
     expect(s.frame()).toContain("what each key runs");
     await s.press(ESC);
@@ -166,7 +205,7 @@ describe("the screens each key opens", () => {
   test("the keyboard is not left dead after closing", async () => {
     // The soft-lock risk: a screen that owns the keyboard but never renders.
     const s = mount();
-    await tick();
+    await s.ready();
     await s.press("p");
     await s.press(ESC);
     await s.press("?");
@@ -176,7 +215,7 @@ describe("the screens each key opens", () => {
 
   test("? lists the keys, and names which one writes", async () => {
     const s = mount();
-    await tick();
+    await s.ready();
     await s.press("?");
     const f = s.frame();
     expect(f).toContain("the only key that writes");
@@ -194,7 +233,7 @@ describe("a key that cannot act says so", () => {
    */
   test("pressing a check key mid-run reports the refusal instead of ignoring it", async () => {
     const s = mount();
-    await tick();
+    await s.ready();
     await s.press("d"); // starts a deep verify
     await s.press("d"); // arrives while the first is still running
     await tick(200);
@@ -209,7 +248,7 @@ describe("a key that cannot act says so", () => {
 
   test("the refusal names the key and what is holding it up", async () => {
     const s = mount();
-    await tick();
+    await s.ready();
     await s.press("q");
     await s.press("d");
     await tick(200);
@@ -233,7 +272,7 @@ describe("a check that could not run says so", () => {
    */
   test("an unreachable destination is reported, not skipped quietly", async () => {
     const s = mount();
-    await tick();
+    await s.ready();
     // Break reachability by removing the sentinel the config was built around.
     rmSync(join(root, "dst", SENTINEL_NAME), { force: true });
     await s.press("r"); // re-read reachability
@@ -262,7 +301,7 @@ describe("the debug log is readable", () => {
     process.env["SYNCY_DEBUG"] = "1";
     try {
       const s = mount();
-      await tick();
+      await s.ready();
       const after = existsSync(log) ? readFileSync(log, "utf8").split("\n").length : 0;
       // Move the cursor a few times: renders, and nothing worth logging.
       for (const _ of [0, 1, 2, 3, 4]) await s.press("j");
@@ -282,7 +321,7 @@ describe("the debug log is readable", () => {
     process.env["SYNCY_DEBUG"] = "1";
     try {
       const s = mount();
-      await tick();
+      await s.ready();
       await s.press("q");
       await waitFor(
         () => existsSync(log) && /check\.(done|skipped)/.test(readFileSync(log, "utf8")),


### PR DESCRIPTION
`.github/workflows/ci.yml`:

- **check** — on `pull_request` and push to `main`, on `ubuntu-latest` and `macos-14`. Installs with `--frozen-lockfile`, installs Homebrew rsync on macOS (the runner ships openrsync only, which syncy refuses), then type-checks, lints (Biome, pinned the same way the local scripts run it) and runs the full suite.
- **release** — on `v*` tags. Cross-compiles all four targets — both macOS ones on one arm64 runner, since `bun build` targets the runtime rather than the host — uploads each binary as a release asset, and publishes a `checksums.txt`.

`scripts/build.ts` drives `bun build --compile` for `bun-darwin-{arm64,x64}` and `bun-linux-{x64,arm64}` with the same flags as the hand-built binary. `bun run build` now takes no argument (this machine's target); `bun run build:all` builds everything. The per-platform commands stay in the README for people who do not want the script.

**The lockfile is unchanged on purpose**: Biome runs through `bunx` with a pinned version (see #1), so CI installs exactly what `bun.lock` records.

README claims the CI-measured runtime test count; `test/readme.test.ts` enforces it stays within a factor of two of the declared count, so a drift is a warning-sized fix, not a red build.