### PR TITLE
Lift the crate as the wheels turn

### DIFF
--- a/src/tui/Forklift.tsx
+++ b/src/tui/Forklift.tsx
@@ -4,25 +4,33 @@ import type { Theme } from "./theme.ts";
 /**
  * The forklift: syncy's mark, top left. Side profile, facing left.
  *
- *     ▓┃▄▄     a crate on the forks, the full-height mast, the low back
+ *     ▄┃█▄     a crate on the forks, the full-height mast, the cab, the low tail
  *     ━┻◍◍     the forks, and two wheels
  *
  * Two rows and four columns, after four earlier attempts. The first had no
  * forks, which is the one feature that makes a forklift legible. The second
  * had forks but so much body detail that nothing resolved. The third was
- * legible but larger than a mark needs to be. The fourth drew the back at full
- * mast height, which made the whole thing read as one solid bar — a forklift is
- * recognisable because its mast is tall and everything behind it is low, so the
- * back is drawn with half-height blocks that sit below the mast's top.
+ * legible but larger than a mark needs to be. The fourth drew the whole back
+ * at full mast height, which made the thing read as one solid bar — a forklift
+ * is recognisable because it steps down behind the mast, so the tail is a
+ * half-height block sitting below the top of the cab.
  *
- * At this size there is no mast for the crate to climb, so the motion is the
- * wheels. It only turns while a check or a sync is running, which means motion
- * on this screen says work is happening and standing still says it is not.
- * That is what earns it a place in an interface that otherwise refuses
- * decoration.
+ * The motion is a load being lifted. The wheels rock and the crate climbs the
+ * mast in the same cycle: on the forks, halfway up, at the top, and back down
+ * — four frames, so a full lift takes just under a second at the 220 ms tick.
+ * Wheels and crate move together because a lift that moved while the wheels
+ * stood still would read as two marks rather than one machine.
+ *
+ * It only moves while a check or a sync is running, which means motion on this
+ * screen says work is happening and standing still says it is not. That is
+ * what earns it a place in an interface that otherwise refuses decoration.
  */
 
-const WHEELS = ["◍◍", "◉◍", "◍◉"] as const;
+/** The wheels rock left, right, left, right — one spoke turning under load. */
+const WHEELS = ["◍◍", "◉◍", "◍◉", "◉◍"] as const;
+
+/** The crate's height on the mast: on the forks, halfway, at the top, halfway. */
+const LIFT = ["▄", "█", "▀", "█"] as const;
 
 export interface ForkliftProps {
   readonly theme: Theme;
@@ -32,9 +40,10 @@ export interface ForkliftProps {
 }
 
 export function forkliftRows(frame: number, moving: boolean): readonly string[] {
-  // Square-on wheels at rest; they only turn while something is running.
-  const wheels = moving ? WHEELS[frame % WHEELS.length]! : WHEELS[0];
-  return ["▓┃▄▄", `━┻${wheels}`];
+  // Square-on wheels and the crate down on the forks at rest; both only move
+  // while something is running, and frame 0 is that resting pose.
+  const phase = moving ? frame % WHEELS.length : 0;
+  return [`${LIFT[phase]!}┃█▄`, `━┻${WHEELS[phase]!}`];
 }
 
 export function Forklift({ theme, frame, moving }: ForkliftProps): React.ReactElement {

--- a/test/mark.test.tsx
+++ b/test/mark.test.tsx
@@ -157,26 +157,49 @@ describe("the forklift moves only while work is happening", () => {
     }
   });
 
-  test("the wheels turn while work is running", () => {
-    const seen = new Set(Array.from({ length: 6 }, (_, f) => forkliftRows(f, true).join("\n")));
-    expect(seen.size).toBe(3);
+  test("it never stalls while work is running", () => {
+    // Every frame differs from the one before it, so the mark never looks
+    // frozen mid-run. There are three distinct poses, not four: the halfway
+    // rung is shared by the way up and the way down.
+    const pose = (f: number) => forkliftRows(f, true).join("\n");
+    for (let f = 1; f < 8; f++) expect(pose(f), `frame ${f}`).not.toBe(pose(f - 1));
+    expect(new Set(Array.from({ length: 8 }, (_, f) => pose(f))).size).toBe(3);
   });
 
   test("the cycle returns to where it started, so it loops cleanly", () => {
-    expect(forkliftRows(3, true)).toEqual(forkliftRows(0, true));
+    expect(forkliftRows(4, true)).toEqual(forkliftRows(0, true));
   });
 
-  test("the crate is always on the forks — it never vanishes", () => {
+  test("the crate is always on the mast — it never vanishes", () => {
+    // It changes height as the lift raises it, but there is always a load.
     for (const moving of [true, false]) {
-      for (let f = 0; f < 6; f++) {
-        expect(forkliftRows(f, moving)[0]?.startsWith("▓"), `frame ${f}`).toBe(true);
+      for (let f = 0; f < 8; f++) {
+        expect(["▄", "█", "▀"], `frame ${f}`).toContain(forkliftRows(f, moving)[0]![0]!);
       }
     }
   });
 
+  test("the crate rises and comes back down, rather than jumping to the top", () => {
+    // Height in half-cells: on the forks, halfway up, at the top.
+    const height = (f: number) => ["▄", "█", "▀"].indexOf(forkliftRows(f, true)[0]![0]!);
+    expect(Array.from({ length: 5 }, (_, f) => height(f))).toEqual([0, 1, 2, 1, 0]);
+  });
+
+  test("the wheels and the crate move in the same cycle, or it reads as two marks", () => {
+    // A lift that moved while the wheels stood still would not read as one machine.
+    const wheelsChanged = forkliftRows(1, true)[1] !== forkliftRows(0, true)[1];
+    const crateChanged = forkliftRows(1, true)[0] !== forkliftRows(0, true)[0];
+    expect(wheelsChanged && crateChanged).toBe(true);
+  });
+
+  test("at rest the crate sits down on the forks", () => {
+    // Idle has to be a pose a real forklift holds, not a frozen mid-lift.
+    expect(forkliftRows(0, false)[0]?.[0]).toBe("▄");
+  });
+
   test("every row is the same width, or the header would shear", () => {
     for (const moving of [true, false]) {
-      for (let f = 0; f < 6; f++) {
+      for (let f = 0; f < 8; f++) {
         const widths = new Set(forkliftRows(f, moving).map((r) => displayWidth(r)));
         expect(widths.size, `frame ${f} moving=${moving}`).toBe(1);
       }
@@ -189,15 +212,16 @@ describe("the forklift moves only while work is happening", () => {
     for (const r of rows) expect(displayWidth(r)).toBe(4);
   });
 
-  test("the back sits below the mast — a full-height back reads as a bar", () => {
-    const top = forkliftRows(0, true)[0]!;
-    expect(top.slice(top.indexOf("┃") + 1)).not.toContain("█");
+  test("the tail steps down behind the cab — a flat back reads as a bar", () => {
+    for (let f = 0; f < 8; f++) {
+      expect(forkliftRows(f, true)[0]?.endsWith("▄"), `frame ${f}`).toBe(true);
+    }
   });
 
   test("the forks are always drawn — they are the defining feature", () => {
     // The first attempt had none, and read as a box beside another box.
     for (const moving of [true, false]) {
-      for (let f = 0; f < 6; f++) expect(forkliftRows(f, moving)[1], `frame ${f}`).toContain("┻");
+      for (let f = 0; f < 8; f++) expect(forkliftRows(f, moving)[1], `frame ${f}`).toContain("┻");
     }
   });
 


### PR DESCRIPTION
The mark was a forklift that could not lift anything. Its only motion was the wheels, on the grounds that two rows leave no mast for a crate to climb — but the middle column already draws a mast, and a cell holds three positions in block glyphs.

```
▄┃█▄   █┃█▄   ▀┃█▄   █┃█▄
━┻◍◍   ━┻◉◍   ━┻◍◉   ━┻◉◍
```

The crate rides the mast: on the forks, halfway up, at the top, back down. Four frames at the existing 220 ms tick, so a full lift takes just under a second.

**Why one phase counter.** Wheels and crate advance off the same `phase`, not two independent loops — a lift that moved while the wheels stood still reads as two marks rather than one machine. Frames 1 and 3 are the same pose by design (the halfway rung is shared by the way up and the way down), but no two *consecutive* frames match, so it never looks stalled. Idle is frame 0: square-on wheels, crate down on the forks.

The wheels went from a three-frame rotation to a four-frame rock to match the lift's period.

### Test changes worth a look

Two assertions in `test/mark.test.tsx` failed before this branch touched anything, because the art had already changed on `main`'s working copy (`▓┃▄▄` → `▄┃█▄`):

- One asserted the crate starts with `▓`. That column is now the animated one, so it asserts the top-left is one of the three lift heights.
- One asserted nothing after the mast is full-height — the old "everything behind the mast is low" rule. The `█` cab breaks that literally. I kept the intent but aimed it at the tail: the last column stays `▄`, so the silhouette still steps down at the back instead of reading as a solid bar. **If the cab was meant to stay low, say so and I'll revert it to `▄▄` and restore the original assertion.**

The doc comment claimed "at this size there is no mast for the crate to climb," which is no longer true; rewritten.

Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)