### PR TITLE
Give the differences screen a time dimension and a shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ resume from it.
 These three, and nothing else:
 
 ```
-quick   -a -A -X -n -i -vv --out-format=%i|%l|%n --delete --exclude=… SRC/ DST/
-deep    -a -A -X -c -n -i -vv --out-format=%i|%l|%n         --exclude=… SRC/ DST/
-sync    -a -A -X -i --out-format=%i|%l|%n
+quick   -a -A -X -n -i -vv --out-format=%i|%l|%M|%n --delete --exclude=… SRC/ DST/
+deep    -a -A -X -c -n -i -vv --out-format=%i|%l|%M|%n         --exclude=… SRC/ DST/
+sync    -a -A -X -i --out-format=%i|%l|%M|%n
         --partial-dir=.syncy-partial                        --exclude=… SRC/ DST/
 ```
 

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -44,6 +44,12 @@ export interface DiffEntry {
   readonly dir: boolean;
   /** False for extras, where rsync reports no size at all. */
   readonly sized: boolean;
+  /**
+   * The source file's mtime, epoch milliseconds. Absent on extras, which have
+   * no source file, and on records written before %M was captured — which the
+   * views report as "undated" rather than guessing.
+   */
+  readonly mtime?: number;
 }
 
 export interface Diff {
@@ -113,6 +119,7 @@ export function buildDiff(
       flags: it.flags,
       dir: kind !== "extra" && it.flags[1] === "d",
       sized: kind !== "extra",
+      ...(it.mtime !== null ? { mtime: it.mtime } : {}),
     });
   }
   const totals: Record<DiffKind, number> = { new: 0, changed: 0, metadata: 0, extra: 0 };
@@ -173,7 +180,8 @@ function isValidEntry(raw: unknown): raw is DiffEntry {
     typeof o["bytes"] === "number" &&
     typeof o["flags"] === "string" &&
     typeof o["dir"] === "boolean" &&
-    typeof o["sized"] === "boolean"
+    typeof o["sized"] === "boolean" &&
+    (o["mtime"] === undefined || (typeof o["mtime"] === "number" && Number.isFinite(o["mtime"])))
   );
 }
 
@@ -212,4 +220,199 @@ export function diffCounts(diff: Diff): Readonly<Record<DiffKind, number>> {
   const out: Record<DiffKind, number> = { new: 0, changed: 0, metadata: 0, extra: 0 };
   for (const e of diff.entries) out[e.kind] += 1;
   return out;
+}
+
+
+/**
+ * When a difference was written, relative to the last sync that ran.
+ *
+ * This is the distinction the screen existed to make and could not: a file
+ * absent from the destination and written *since* the last sync is an ordinary
+ * backlog — nothing has gone wrong, the copy simply has not happened yet. A
+ * file absent from the destination that was written *before* the last sync
+ * should already be there. Something skipped it: an exclude rule that matches
+ * more than intended, a permissions failure, an interrupted run.
+ *
+ * "before" is a reason to look, not proof of a fault. Mtimes are preserved by
+ * camera imports, `cp -p` and restored backups, so a genuinely new file can
+ * carry an old date. The wording throughout says which side of the sync a file
+ * falls on and never claims to know why.
+ */
+export type SyncAge = "since" | "before" | "undated";
+
+export function ageAgainstSync(entry: DiffEntry, lastSyncTs: number | null): SyncAge {
+  if (lastSyncTs === null || entry.mtime === undefined) return "undated";
+  return entry.mtime >= lastSyncTs ? "since" : "before";
+}
+
+export interface SyncSplit {
+  readonly since: number;
+  readonly before: number;
+  readonly undated: number;
+  readonly lastSyncTs: number | null;
+}
+
+/**
+ * The split across everything a sync would copy — `new` and `changed` only.
+ *
+ * Extras are at the destination and not the source, and metadata differences
+ * are already present at both; neither is a file waiting to be copied, so
+ * neither belongs in a count that answers "why is this not there yet".
+ */
+export function splitBySync(diff: Diff, lastSyncTs: number | null): SyncSplit {
+  let since = 0;
+  let before = 0;
+  let undated = 0;
+  for (const e of diff.entries) {
+    if (e.kind !== "new" && e.kind !== "changed") continue;
+    const age = ageAgainstSync(e, lastSyncTs);
+    if (age === "since") since += 1;
+    else if (age === "before") before += 1;
+    else undated += 1;
+  }
+  return { since, before, undated, lastSyncTs };
+}
+
+/** How the listing is divided up. `flat` is the original file-by-file listing. */
+export type GroupBy = "folder" | "type" | "age" | "flat";
+
+export const GROUP_BY: readonly GroupBy[] = ["folder", "type", "age", "flat"];
+
+/** The directory part of an entry's name, or "" for one at the unit's root. */
+export function folderOf(name: string): string {
+  const cut = name.replace(/\/+$/, "").lastIndexOf("/");
+  return cut < 0 ? "" : name.slice(0, cut);
+}
+
+/** The extension, lowercased and with its dot, or "" for a name without one. */
+export function typeOf(entry: DiffEntry): string {
+  if (entry.dir) return "";
+  const base = entry.name.slice(entry.name.lastIndexOf("/") + 1);
+  const dot = base.lastIndexOf(".");
+  return dot <= 0 ? "" : base.slice(dot).toLowerCase();
+}
+
+/** Age buckets, coarse enough that a shoot lands in one and reads as one. */
+const BUCKETS: readonly (readonly [string, number])[] = [
+  ["today", 1],
+  ["this week", 7],
+  ["this month", 31],
+  ["this year", 365],
+];
+
+export function ageBucket(mtime: number | undefined, now: number): string {
+  if (mtime === undefined) return "undated";
+  const days = (now - mtime) / 86_400_000;
+  for (const [label, within] of BUCKETS) {
+    if (days < within) return label;
+  }
+  return "older";
+}
+
+export interface DiffGroup {
+  readonly key: string;
+  readonly label: string;
+  readonly kind: DiffKind;
+  readonly entries: readonly DiffEntry[];
+  /** Bytes a sync would move for this group; zero for extras and directories. */
+  readonly bytes: number;
+  /** Extensions by frequency, most common first. */
+  readonly types: readonly (readonly [string, number])[];
+  readonly oldest: number | null;
+  readonly newest: number | null;
+  /** The shared itemize string when every entry has the same one, else null. */
+  readonly flags: string | null;
+  /** True when every entry in the group predates the last sync. */
+  readonly before: boolean;
+}
+
+/**
+ * The listing, divided.
+ *
+ * Grouped by kind first and always: the glyph, the wording and the urgency all
+ * belong to the kind, and a folder holding both a creation and a content
+ * difference is holding two unrelated facts. Within a kind, `new` and `changed`
+ * are divided again by which side of the last sync they fall on, so the handful
+ * that should already be at the destination cannot hide inside a group of five
+ * hundred that are merely waiting.
+ */
+export function groupDiff(
+  entries: readonly DiffEntry[],
+  by: GroupBy,
+  lastSyncTs: number | null,
+  now: number,
+): DiffGroup[] {
+  const buckets = new Map<string, DiffEntry[]>();
+  const labels = new Map<string, string>();
+  const sides = new Map<string, boolean>();
+  for (const e of entries) {
+    const age = ageAgainstSync(e, lastSyncTs);
+    // Only the copyable kinds are split by the sync: an extra or an attribute
+    // difference is not waiting to be copied, so "before the last sync" says
+    // nothing about it.
+    const side = (e.kind === "new" || e.kind === "changed") && age === "before" ? "before" : "since";
+    const label =
+      by === "folder"
+        ? folderOf(e.name) || "."
+        : by === "type"
+          ? typeOf(e) || "no extension"
+          : ageBucket(e.mtime, now);
+    const key = `${e.kind}\u0000${side}\u0000${label}`;
+    labels.set(key, label);
+    sides.set(key, side === "before");
+    const at = buckets.get(key);
+    if (at === undefined) buckets.set(key, [e]);
+    else at.push(e);
+  }
+
+  const out: DiffGroup[] = [];
+  for (const [key, list] of buckets) {
+    let bytes = 0;
+    let oldest: number | null = null;
+    let newest: number | null = null;
+    const types = new Map<string, number>();
+    let flags: string | null = list[0]!.flags;
+    for (const e of list) {
+      if (e.sized && !e.dir) bytes += e.bytes;
+      if (e.mtime !== undefined) {
+        if (oldest === null || e.mtime < oldest) oldest = e.mtime;
+        if (newest === null || e.mtime > newest) newest = e.mtime;
+      }
+      const t = typeOf(e);
+      if (t !== "") types.set(t, (types.get(t) ?? 0) + 1);
+      if (flags !== e.flags) flags = null;
+    }
+    out.push({
+      key,
+      label: labels.get(key)!,
+      kind: list[0]!.kind,
+      entries: list,
+      bytes,
+      types: [...types].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])),
+      oldest,
+      newest,
+      flags,
+      before: sides.get(key)!,
+    });
+  }
+  return out.sort((a, b) => rank(a) - rank(b) || b.bytes - a.bytes || a.label.localeCompare(b.label));
+}
+
+/**
+ * What a group is worth looking at first.
+ *
+ * Not the same order as the legend. The legend lists kinds by what is at risk;
+ * this ranks groups by what is surprising, and those come apart badly at scale.
+ * A folder of 504 creations from yesterday outranked one file whose content
+ * differs, purely because "not at destination" sorts before "content differs" —
+ * so the single interesting row landed at position 505 of a windowed list and
+ * was, in practice, unreachable. The bulk backlog is the least surprising thing
+ * on the screen and now sorts near the bottom.
+ */
+function rank(g: DiffGroup): number {
+  if (g.before) return 0; // should already be at the destination, and is not
+  if (g.kind === "changed") return 1;
+  if (g.kind === "metadata") return 2;
+  if (g.kind === "new") return 3; // the ordinary backlog
+  return 4; // extras, which syncy never acts on
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -38,10 +38,38 @@ export function ageAgo(ts: number, now: number = Date.now()): string {
   return a === "today" ? "today" : `${a} ago`;
 }
 
+const MONTHS = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
+
+/**
+ * A date without a time, for spans where the hour is noise: "14 feb".
+ *
+ * The year appears only when it is not the current one. A file from April 2023
+ * shown as "26 apr" beside a backlog from this February reads as six weeks old
+ * when it is ten months old — and on this screen that difference is the whole
+ * point of showing a date at all.
+ */
+export function day(ts: number, now: number = Date.now()): string {
+  const d = new Date(ts);
+  const year = d.getFullYear() === new Date(now).getFullYear() ? "" : ` ${d.getFullYear()}`;
+  return `${d.getDate()} ${MONTHS[d.getMonth()]}${year}`;
+}
+
+/**
+ * A span of dates, collapsed when both ends land on the same day.
+ *
+ * A shoot arrives over an afternoon or a long weekend, so the useful reading is
+ * "4–14 feb", not two timestamps a reader has to subtract in their head.
+ */
+export function span(from: number | null, to: number | null, now: number = Date.now()): string | null {
+  if (from === null || to === null) return null;
+  const a = day(from, now);
+  const b = day(to, now);
+  return a === b ? a : `${a}–${b}`;
+}
+
 export function stamp(ts: number): string {
   const d = new Date(ts);
-  const months = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
   const hh = String(d.getHours()).padStart(2, "0");
   const mm = String(d.getMinutes()).padStart(2, "0");
-  return `${d.getDate()} ${months[d.getMonth()]} · ${hh}:${mm}`;
+  return `${day(ts)} · ${hh}:${mm}`;
 }

--- a/src/itemize.ts
+++ b/src/itemize.ts
@@ -1,8 +1,9 @@
 /**
- * Parser for rsync's --itemize-changes under --out-format='%i|%l|%n'.
+ * Parser for rsync's --itemize-changes under --out-format='%i|%l|%M|%n'.
  *
- * %i is the 11-character itemize string, %l the byte length, %n the name.
- * Deletions arrive as a literal `*deleting` in the %i field.
+ * %i is the 11-character itemize string, %l the byte length, %M the source
+ * file's modification time, %n the name. Deletions arrive as a literal
+ * `*deleting` in the %i field.
  */
 
 export type ItemKind = "change" | "metadata" | "same" | "extra";
@@ -12,6 +13,37 @@ export interface Item {
   readonly bytes: number;
   readonly name: string;
   readonly kind: ItemKind;
+  /**
+   * The source file's mtime in epoch milliseconds, or null when rsync reported
+   * none. Null for deletions, which describe a file that is not at the source
+   * at all and for which rsync prints the epoch.
+   */
+  readonly mtime: number | null;
+}
+
+/**
+ * rsync's %M, `YYYY/MM/DD-HH:MM:SS`, in the machine's own timezone — it prints
+ * local time and no offset, so it is read as local time.
+ *
+ * Shape-checked rather than handed to `Date.parse`, because the check is also
+ * what tells a real timestamp field apart from a filename fragment: names may
+ * contain the `|` delimiter (rsync does not escape it), so a three-field line
+ * and a four-field line whose name contains a pipe are otherwise identical.
+ */
+const MTIME = /^(\d{4})\/(\d{2})\/(\d{2})-(\d{2}):(\d{2}):(\d{2})$/;
+
+export function parseMtime(field: string): number | null {
+  const m = MTIME.exec(field.trim());
+  if (m === null) return null;
+  const ms = new Date(
+    Number(m[1]), Number(m[2]) - 1, Number(m[3]),
+    Number(m[4]), Number(m[5]), Number(m[6]),
+  ).getTime();
+  // rsync prints the epoch for an item with no source file — every `*deleting`
+  // line carries it. A real archive holds nothing from before 1970, so
+  // treating that as "no timestamp" costs nothing and avoids dating an extra
+  // to the first second of 1970 on the age histogram.
+  return Number.isFinite(ms) && ms > 0 ? ms : null;
 }
 
 export interface Summary {
@@ -49,19 +81,26 @@ export function parseItemizeLine(line: string): Item | null {
   if (raw === "") return null;
 
   const first = raw.indexOf("|");
-  const last = raw.indexOf("|", first + 1);
-  if (first < 0 || last < 0) return null;
+  const second = raw.indexOf("|", first + 1);
+  if (first < 0 || second < 0) return null;
 
   const flags = raw.slice(0, first).trim();
-  const lenField = raw.slice(first + 1, last).trim();
-  const name = raw.slice(last + 1);
+  const lenField = raw.slice(first + 1, second).trim();
+
+  // The third field is the timestamp when it is shaped like one. Records
+  // written before %M was asked for have the name there instead, and a name is
+  // never shaped like a timestamp — so the shape decides, and an older log
+  // replays as an undated entry rather than as a parse failure.
+  const third = raw.indexOf("|", second + 1);
+  const mtime = third < 0 ? null : parseMtime(raw.slice(second + 1, third));
+  const name = mtime === null ? raw.slice(second + 1) : raw.slice(third + 1);
   if (name === "") return null;
 
   // `*deleting` means the file exists at the destination but not at the source.
   // Under --dry-run this is informational only; extras never endanger source
   // data and so never prevent a `verified` status (DESIGN.md §3).
   if (flags.startsWith("*deleting")) {
-    return { flags, bytes: 0, name, kind: "extra" };
+    return { flags, bytes: 0, name, kind: "extra", mtime };
   }
   const m = ITEMIZE.exec(flags);
   if (m === null) return null;
@@ -71,6 +110,7 @@ export function parseItemizeLine(line: string): Item | null {
     flags,
     bytes: Number.isFinite(bytes) ? bytes : 0,
     name,
+    mtime,
     // Column 1 of `.` means the item is not being updated. Under -vv rsync
     // emits one such line per file it has finished with, so the blank-flag
     // case is a progress tick rather than a difference: `.f         ` is

--- a/src/rsync.ts
+++ b/src/rsync.ts
@@ -36,7 +36,13 @@ export function resolveRsync(env: NodeJS.ProcessEnv = process.env): string {
 }
 
 export const DEFAULT_RSYNC: string = resolveRsync();
-export const OUT_FORMAT = "%i|%l|%n";
+/**
+ * %M — the source file's mtime — rides along with the fields already asked
+ * for. It is what lets the differences screen separate a file written since
+ * the last sync from one that predates it and never copied; without it the
+ * listing has no time dimension at all and every difference looks alike.
+ */
+export const OUT_FORMAT = "%i|%l|%M|%n";
 export const PARTIAL_DIR = ".syncy-partial";
 
 export type Mode = "quick" | "deep" | "sync";

--- a/src/state.ts
+++ b/src/state.ts
@@ -313,3 +313,50 @@ export function estimateMs(
   if (sampleBytes <= 0 || sampleMs <= 0) return undefined;
   return Math.round((bytes * sampleMs) / sampleBytes);
 }
+
+/**
+ * When a sync of this unit last reached this destination.
+ *
+ * The differences screen needs it to say which side of the last sync a missing
+ * file falls on, which is the difference between an ordinary backlog and a file
+ * that should already be there.
+ *
+ * Read from the history rather than from `state.json`, because a scan records
+ * only checks: the scan records say when syncy last *looked*, and this has to
+ * answer when it last *copied*. Exit 24 counts alongside 0 for the same reason
+ * `checkUnit` treats it as success — files vanishing mid-run is routine on a
+ * live archive and does not mean nothing was transferred.
+ *
+ * Returns null when nothing has ever synced, which the view reports as such
+ * rather than dating everything from the epoch.
+ */
+export function lastSyncAt(
+  unit: string,
+  target: string,
+  file: string = historyFile(),
+): number | null {
+  let text: string;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch {
+    return null; // Nothing has ever synced; the file is written on first run.
+  }
+  let best: number | null = null;
+  for (const line of text.split("\n")) {
+    if (line.trim() === "") continue;
+    let raw: unknown;
+    try {
+      raw = JSON.parse(line);
+    } catch {
+      continue; // One torn line at the tail must not hide every sync before it.
+    }
+    if (typeof raw !== "object" || raw === null) continue;
+    const o = raw as Record<string, unknown>;
+    if (o["unit"] !== unit || o["target"] !== target) continue;
+    if (o["exitCode"] !== 0 && o["exitCode"] !== 24) continue;
+    const ts = o["ts"];
+    if (typeof ts !== "number" || !Number.isFinite(ts)) continue;
+    if (best === null || ts > best) best = ts;
+  }
+  return best;
+}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -5,7 +5,15 @@ import type { Config } from "../config.ts";
 import { EMPTY as EMPTY_FINGERPRINT, fingerprint, type Fingerprint } from "../fingerprint.ts";
 import { bytes } from "../format.ts";
 import { allReachability, checkUnit, listUnits, methodOf, type Reachability } from "../scan.ts";
-import { appendHistory, estimateMs, loadState, saveState, upsertScan, type State } from "../state.ts";
+import {
+  appendHistory,
+  estimateMs,
+  lastSyncAt,
+  loadState,
+  saveState,
+  upsertScan,
+  type State,
+} from "../state.ts";
 import { debug, timed, timedAsync } from "../log.ts";
 import { setTitle, titleFor } from "../title.ts";
 import { padEnd, truncatePath } from "../width.ts";
@@ -232,6 +240,15 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
     const unit = rows[clampedSelection]?.status.unit;
     if (!showDiff || unit === undefined) return new Map<string, Diff | null>();
     return new Map(config.targets.map((t) => [t.name, loadDiff(unit, t.name)]));
+  }, [showDiff, rows, clampedSelection, config.targets, state]);
+
+  // Read on the same terms as the diffs themselves: the differences screen is
+  // the only thing that asks when a sync last landed, and it has to be the
+  // sync that just finished rather than the one recorded when the app opened.
+  const lastSync: ReadonlyMap<string, number | null> = useMemo(() => {
+    const unit = rows[clampedSelection]?.status.unit;
+    if (!showDiff || unit === undefined) return new Map<string, number | null>();
+    return new Map(config.targets.map((t) => [t.name, lastSyncAt(unit, t.name)]));
   }, [showDiff, rows, clampedSelection, config.targets, state]);
 
   const runCheck = useCallback(
@@ -608,6 +625,7 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
           config={config}
           unit={row.status.unit}
           diffs={diffs}
+          lastSync={lastSync}
           theme={theme}
           width={width}
           height={screen.rows}

--- a/src/tui/Diff.tsx
+++ b/src/tui/Diff.tsx
@@ -1,9 +1,21 @@
 import { Box, Text, useInput } from "ink";
 import { useMemo, useState } from "react";
 import type { Config } from "../config.ts";
-import { diffCounts, type Diff, type DiffEntry, type DiffKind } from "../diff.ts";
+import {
+  diffCounts,
+  folderOf,
+  groupDiff,
+  splitBySync,
+  GROUP_BY,
+  type Diff,
+  type DiffEntry,
+  type DiffGroup,
+  type DiffKind,
+  type GroupBy,
+  type SyncSplit,
+} from "../diff.ts";
 import { explainFlags } from "../itemize.ts";
-import { ageAgo, bytes, count } from "../format.ts";
+import { ageAgo, bytes, count, day, span } from "../format.ts";
 import { displayWidth, padEnd, padStart, truncate, truncatePath } from "../width.ts";
 import { Rule, Screen } from "./Screen.tsx";
 import type { Theme } from "./theme.ts";
@@ -16,6 +28,20 @@ import type { Theme } from "./theme.ts";
  * tell a real gap from a stale record. This lists them, in the same words the
  * status column uses, with rsync's own itemize string alongside so the claim is
  * checkable rather than asserted.
+ *
+ * The flat listing that produced was still unreadable at the size that matters.
+ * A folder 504 files behind drew 504 rows carrying two facts each — a name and
+ * a size — under an itemize column that repeated `>f+++++++++` five hundred
+ * times, because a creation has nothing else to say. Everything a reader
+ * actually wanted was a property of the *set*: one shoot or five, raw files or
+ * sidecars, a week's backlog or a year's. So the listing is grouped, each group
+ * states those properties, and the file-by-file view is one keypress away for
+ * when a name is what you need.
+ *
+ * The ordering changed with it. `ORDER` ranks kinds by what is at risk, which
+ * put 504 routine creations above the single file whose attributes differed —
+ * at row 505 of a windowed list, which is to say nowhere. Groups are ranked by
+ * what is surprising instead (`groupDiff`), and the bulk backlog sinks.
  *
  * Nothing here offers to delete. Extras — files at the destination with no
  * counterpart at the source — are shown because they are worth knowing about,
@@ -56,6 +82,15 @@ const TOKEN: Readonly<Record<DiffKind, "missing" | "behind" | "dim" | "unverifie
 };
 
 /**
+ * How many entries a group may hold before it opens closed.
+ *
+ * Small groups behave exactly as the flat listing always did — there is nothing
+ * to be gained by hiding four files behind a disclosure. Past this, the header
+ * says more than the rows do.
+ */
+export const COLLAPSE_OVER = 8;
+
+/**
  * The legend, in the widest wording that fits.
  *
  * The full labels wrapped at 76 columns and Ink broke "destination" across two
@@ -74,6 +109,10 @@ export interface DiffProps {
   readonly unit: string;
   /** One entry per configured target; null means no check has been recorded. */
   readonly diffs: ReadonlyMap<string, Diff | null>;
+  /** When each destination last had a sync land, for the age split. */
+  readonly lastSync?: ReadonlyMap<string, number | null>;
+  /** The grouping the screen opens on. [b] cycles from wherever this leaves it. */
+  readonly by?: GroupBy;
   readonly theme: Theme;
   readonly width: number;
   readonly height?: number;
@@ -127,6 +166,76 @@ export function magnitudeLine(diff: Diff | null): string | null {
   return `${here}   ${there}   ${parts.join(" · ")}`;
 }
 
+/** The fingerprint's newest mtime in milliseconds, or null when it holds none. */
+function newestOf(ns: string | undefined): number | null {
+  if (ns === undefined) return null;
+  try {
+    const ms = Number(BigInt(ns) / 1_000_000n);
+    return ms > 0 ? ms : null;
+  } catch {
+    return null; // A hand-edited record; the lag line is not worth throwing for.
+  }
+}
+
+/**
+ * How far behind the destination's newest file is.
+ *
+ * Both fingerprints already recorded `maxMtimeNs` and nothing read them. It is
+ * the cheapest true statement this screen can make: it needs no listing, no
+ * itemize parsing and no cap, and it reframes a wall of five hundred red
+ * plusses as the one sentence a reader wants — that nothing has landed here
+ * since the third of February.
+ */
+export function lagLine(diff: Diff | null, now: number = Date.now()): string | null {
+  const here = newestOf(diff?.sourceHolds?.maxMtimeNs);
+  const there = newestOf(diff?.targetHolds?.maxMtimeNs);
+  if (here === null || there === null) return null;
+  const both = `newest here ${day(here, now)} · there ${day(there, now)}`;
+  const days = Math.floor((here - there) / 86_400_000);
+  if (days <= 0) return `${both} · level`;
+  return `${both} · ${days === 1 ? "1 day" : `${days} days`} behind`;
+}
+
+/**
+ * Which side of the last sync the pending files fall on.
+ *
+ * The distinction the screen could not previously draw, and the one that
+ * decides whether anything is wrong. Files written since the last sync are a
+ * backlog: nothing failed, the copy has not run. Files written before it and
+ * still absent were skipped by something.
+ *
+ * Deliberately hedged. Mtimes survive camera imports, `cp -p` and restores, so
+ * an old date does not prove a file was present when the sync ran — the wording
+ * says which side of the line a file falls on and stops there.
+ */
+export function syncLine(split: SyncSplit, now: number): readonly string[] {
+  const total = split.since + split.before + split.undated;
+  if (total === 0) return [];
+  if (split.lastSyncTs === null) return ["no sync has run here yet"];
+
+  // One line, both counts. Two lines each opening with a number read as two
+  // separate findings; they are one finding with a split in it. The totals are
+  // left out because the summary line above states them — the only new fact
+  // here is where the line falls.
+  // "the 13 feb sync" rather than "the last sync (13 feb)": the date is the new
+  // fact and the article is not. Five cells, and the line has to survive
+  // truncation at 76 with all four clauses present.
+  const when = `the ${day(split.lastSyncTs, now)} sync`;
+  const parts: string[] = [];
+  if (split.before > 0) parts.push(`${count(split.before)} predate ${when}`);
+  if (split.since > 0) {
+    parts.push(parts.length === 0 ? `all written since ${when}` : `${count(split.since)} after`);
+  }
+  if (split.undated > 0) parts.push(`${count(split.undated)} undated`);
+  // The caveat earns its place only when something is on the older side of the
+  // line, and only at this length: the reader knows what an mtime is, and a
+  // sentence about camera imports would cost more width than the finding. It
+  // goes last and must still fit — a hedge truncated off the end leaves the
+  // number reading as a certainty.
+  if (split.before > 0) parts.push("imports preserve dates");
+  return [parts.join(" · ")];
+}
+
 /** Bytes rsync would transfer: files it would create or replace, not extras. */
 export function pendingBytes(diff: Diff): number {
   return diff.entries
@@ -134,35 +243,101 @@ export function pendingBytes(diff: Diff): number {
     .reduce((a, e) => a + e.bytes, 0);
 }
 
+/**
+ * What a group is, in one line: how much, of what, from when.
+ *
+ * These are the facts a reader was previously expected to infer by scrolling.
+ * The type mix is capped at three — beyond that it is a histogram, not a label.
+ */
+export function groupDetail(g: DiffGroup, now: number = Date.now()): string {
+  // First, not last. The detail is truncated to the window, and this annotation
+  // is the reason the group is at the top of the screen — trailing it behind
+  // the type mix meant the one line that said "this is a gap, not a backlog"
+  // was the first thing a narrow window threw away.
+  const parts: string[] = g.before ? ["predates the last sync"] : [];
+  parts.push(`${count(g.entries.length)} ${g.entries.length === 1 ? "file" : "files"}`);
+  if (g.bytes > 0) parts.push(bytes(g.bytes));
+  const types = g.types.slice(0, 3).map(([ext, n]) => `${ext} ${count(n)}`);
+  if (g.types.length > 3) types.push(`+${g.types.length - 3} more`);
+  if (types.length > 0) parts.push(types.join(" "));
+  const when = span(g.oldest, g.newest, now);
+  if (when !== null) parts.push(when);
+  // One shared itemize string says the same thing on every row underneath it,
+  // so it is said here instead and the rows drop the column entirely. Both the
+  // reading and the raw string come up here — moving the column onto the header
+  // is a change of place, and dropping the evidence to save width would be a
+  // change of claim.
+  if (g.flags !== null) {
+    const why = explainFlags(g.flags);
+    parts.push(why ?? (g.kind === "new" ? "all created new" : ""), g.flags);
+  }
+  return parts.filter((p) => p !== "").join(" · ");
+}
+
+/**
+ * The cursor, in the ledger's own glyph, drawn inside the row's indent.
+ *
+ * Occupying space the indent already spends is what keeps every column aligned
+ * between a selected row and its neighbours — a marker that pushed the row
+ * right would make the listing jitter as the cursor moved through it.
+ */
+function cursorMark(selected: boolean, indent: number): string {
+  return (selected ? "» " : "  ") + " ".repeat(Math.max(0, indent - 2));
+}
+
 function Entry({
   entry,
   theme,
   width,
+  indent,
+  strip,
+  showFlags,
+  now,
+  selected,
 }: {
   readonly entry: DiffEntry;
   readonly theme: Theme;
   readonly width: number;
+  readonly now: number;
+  readonly indent: number;
+  /** The group's folder, dropped from the name because the header carries it. */
+  readonly strip: string;
+  readonly showFlags: boolean;
+  readonly selected: boolean;
 }): React.ReactElement {
-  // The itemize string is fixed-width and the size column is narrow, so the
-  // name gets everything left over and is truncated in the middle: the tail of
-  // a path identifies a file far better than its head.
   // Extras carry no size: rsync's `*deleting` line reports the name only.
   const size = !entry.sized ? "—" : entry.dir ? "dir" : bytes(entry.bytes);
   // The itemize string is exact and unreadable without the manual open, so the
   // plain reading sits beside it: `.f...p.....` next to "permissions". The raw
   // string stays because it is the evidence; the words are what make it useful.
-  const why = explainFlags(entry.flags);
+  // Both drop out when every row in the group shares one string, which the group
+  // header then states once — 504 identical columns are not evidence, they are
+  // one piece of evidence copied 504 times.
+  const why = showFlags ? explainFlags(entry.flags) : null;
   const WHY = 18;
-  const nameW = Math.max(14, width - 4 - 12 - 2 - 9 - (why === null ? 0 : WHY));
+  const flags = showFlags ? "  " + entry.flags : "";
+  // Wide enough for a date carrying a year; a cross-year file is exactly the
+  // one whose date the reader must not misread.
+  const when = entry.mtime === undefined ? "" : "  " + padStart(day(entry.mtime, now), 11);
+  const name =
+    strip !== "" && entry.name.startsWith(strip + "/")
+      ? entry.name.slice(strip.length + 1)
+      : entry.name;
+  const nameW = Math.max(
+    14,
+    width - indent - 2 - 10 - displayWidth(when) - displayWidth(flags) - (why === null ? 0 : WHY),
+  );
   return (
     <Box>
-      <Text color={theme[TOKEN[entry.kind]]}>{`    ${GLYPH[entry.kind]} `}</Text>
-      <Text color={theme.ink}>{padEnd(truncatePath(entry.name, nameW), nameW)}</Text>
+      <Text color={theme.ink}>{cursorMark(selected, indent)}</Text>
+      <Text color={theme[TOKEN[entry.kind]]}>{`${GLYPH[entry.kind]} `}</Text>
+      <Text color={theme.ink} bold={selected}>{padEnd(truncatePath(name, nameW), nameW)}</Text>
       <Text color={theme.dim}>{padStart(size, 10)}</Text>
+      <Text color={theme.dim}>{when}</Text>
       {why === null ? null : (
         <Text color={theme.unverified}>{"  " + padEnd(truncate(why, WHY - 2), WHY - 2)}</Text>
       )}
-      <Text color={theme.rule}>{"  " + entry.flags}</Text>
+      <Text color={theme.rule}>{flags}</Text>
     </Box>
   );
 }
@@ -175,33 +350,141 @@ function Entry({
 export type DiffRow =
   | { readonly kind: "header"; readonly target: string; readonly diff: Diff | null }
   | { readonly kind: "magnitude"; readonly text: string }
-  | { readonly kind: "entry"; readonly target: string; readonly entry: DiffEntry }
+  | { readonly kind: "lag"; readonly text: string }
+  | { readonly kind: "verdict"; readonly text: string; readonly alarm: boolean }
+  | {
+      readonly kind: "group";
+      readonly target: string;
+      readonly id: string;
+      readonly group: DiffGroup;
+      readonly open: boolean;
+    }
+  | {
+      readonly kind: "entry";
+      readonly target: string;
+      readonly entry: DiffEntry;
+      readonly indent: number;
+      readonly strip: string;
+      readonly showFlags: boolean;
+    }
   | { readonly kind: "note"; readonly text: string }
   | { readonly kind: "blank" };
+
+export interface RowOptions {
+  readonly lastSync?: ReadonlyMap<string, number | null>;
+  readonly by?: GroupBy;
+  /** Group ids whose default open state the reader has flipped. */
+  readonly toggled?: ReadonlySet<string>;
+  readonly now?: number;
+}
+
+/** A group's identity, stable across re-renders so a toggle survives a refresh. */
+export function groupId(target: string, key: string): string {
+  return `${target}\u0000${key}`;
+}
 
 export function diffRows(
   targets: readonly string[],
   diffs: ReadonlyMap<string, Diff | null>,
+  opts: RowOptions = {},
 ): DiffRow[] {
+  const by = opts.by ?? "folder";
+  const toggled = opts.toggled ?? new Set<string>();
+  const now = opts.now ?? Date.now();
   const rows: DiffRow[] = [];
   for (const target of targets) {
     const diff = diffs.get(target) ?? null;
     rows.push({ kind: "header", target, diff });
     const magnitude = magnitudeLine(diff);
     if (magnitude !== null) rows.push({ kind: "magnitude", text: magnitude });
-    const entries =
-      diff === null
-        ? []
-        : [...diff.entries].sort(
-            (a, b) => ORDER.indexOf(a.kind) - ORDER.indexOf(b.kind) || a.name.localeCompare(b.name),
-          );
-    for (const entry of entries) rows.push({ kind: "entry", target, entry });
-    if ((diff?.truncated ?? 0) > 0) {
-      rows.push({ kind: "note", text: `… ${diff!.truncated} more were not recorded (cap reached)` });
+    const lag = lagLine(diff, now);
+    if (lag !== null) rows.push({ kind: "lag", text: lag });
+
+    if (diff === null) {
+      rows.push({ kind: "blank" });
+      continue;
+    }
+
+    const lastSync = opts.lastSync?.get(target) ?? null;
+    for (const text of syncLine(splitBySync(diff, lastSync), now)) {
+      rows.push({ kind: "verdict", text, alarm: text.includes("predate") });
+    }
+
+    if (by === "flat") {
+      const entries = [...diff.entries].sort(
+        (a, b) => ORDER.indexOf(a.kind) - ORDER.indexOf(b.kind) || a.name.localeCompare(b.name),
+      );
+      for (const entry of entries) {
+        rows.push({ kind: "entry", target, entry, indent: 4, strip: "", showFlags: true });
+      }
+    } else {
+      for (const group of groupDiff(diff.entries, by, lastSync, now)) {
+        // A group of one has nothing to summarise: its header and its row would
+        // carry the same facts twice. The entry stands on its own, with the
+        // itemize column it would otherwise have surrendered to the header.
+        const only = group.entries[0];
+        if (group.entries.length === 1 && only !== undefined) {
+          rows.push({ kind: "entry", target, entry: only, indent: 4, strip: "", showFlags: true });
+          continue;
+        }
+        const id = groupId(target, group.key);
+        const open = (group.entries.length <= COLLAPSE_OVER) !== toggled.has(id);
+        rows.push({ kind: "group", target, id, group, open });
+        if (!open) continue;
+        // Only a folder group's label is a prefix of its entries' names; the
+        // type and age groupings cut across directories, so nothing is stripped.
+        const strip = by === "folder" && group.label !== "." ? group.label : "";
+        const sorted = [...group.entries].sort((a, b) => a.name.localeCompare(b.name));
+        for (const entry of sorted) {
+          rows.push({
+            kind: "entry",
+            target,
+            entry,
+            indent: 6,
+            strip,
+            showFlags: group.flags === null,
+          });
+        }
+      }
+    }
+
+    if (diff.truncated > 0) {
+      rows.push({ kind: "note", text: `… ${diff.truncated} more were not recorded (cap reached)` });
     }
     rows.push({ kind: "blank" });
   }
   return rows;
+}
+
+/**
+ * The rows a cursor may land on: the ones that draw a selection.
+ *
+ * Headers, totals, the lag line and the sync split are statements, not targets.
+ * While the cursor indexed every row, arrowing down from the top moved through
+ * four or five of them with nothing on screen changing — the key appeared dead
+ * until the cursor happened to reach the listing. Movement now steps between
+ * the rows that can show they are selected, and the prose is scrolled past
+ * rather than walked through.
+ */
+export function selectableRows(rows: readonly DiffRow[]): number[] {
+  const out: number[] = [];
+  rows.forEach((r, i) => {
+    if (r.kind === "group" || r.kind === "entry") out.push(i);
+  });
+  return out;
+}
+
+/**
+ * The nearest selectable row at or after `from`, else the last one.
+ *
+ * Needed on every read, not only on movement: opening a group or changing the
+ * grouping rebuilds the list underneath a cursor that was an index into the
+ * old one.
+ */
+export function snapTo(selectable: readonly number[], from: number): number {
+  if (selectable.length === 0) return 0;
+  for (const i of selectable) if (i >= from) return i;
+  return selectable[selectable.length - 1]!;
 }
 
 /** Keeps the cursor on screen, scrolling only when it would otherwise leave. */
@@ -215,11 +498,55 @@ export function windowFor(
   return { start, end: start + room };
 }
 
+function Group({
+  row,
+  theme,
+  width,
+  now,
+  selected,
+}: {
+  readonly row: Extract<DiffRow, { kind: "group" }>;
+  readonly theme: Theme;
+  readonly width: number;
+  readonly now: number;
+  readonly selected: boolean;
+}): React.ReactElement {
+  const g = row.group;
+  // A group small enough never to close gets no marker: a disclosure triangle
+  // that does nothing is a promise the screen cannot keep.
+  const marker = g.entries.length <= COLLAPSE_OVER ? " " : row.open ? "▾" : "▸";
+  const labelW = Math.min(34, Math.max(16, Math.floor(width / 3)));
+  return (
+    <Box>
+      <Text color={selected ? theme.ink : theme.rule}>{`${cursorMark(selected, 2)}${marker} `}</Text>
+      <Text color={theme[TOKEN[g.kind]]}>{`${GLYPH[g.kind]} `}</Text>
+      <Text color={theme.ink} bold={selected}>
+        {padEnd(truncatePath(g.label, labelW), labelW)}
+      </Text>
+      <Text color={g.before ? theme.missing : theme.dim}>
+        {"  " + truncate(groupDetail(g, now), Math.max(8, width - labelW - 8))}
+      </Text>
+    </Box>
+  );
+}
+
 export function Diff(props: DiffProps): React.ReactElement {
   const { config, unit, diffs, theme, width, now, onClose } = props;
+  const [by, setBy] = useState<GroupBy>(props.by ?? "folder");
+  const [toggled, setToggled] = useState<ReadonlySet<string>>(() => new Set<string>());
   const rows = useMemo(
-    () => diffRows(config.targets.map((t) => t.name), diffs),
-    [config.targets, diffs],
+    () =>
+      diffRows(
+        config.targets.map((t) => t.name),
+        diffs,
+        {
+          ...(props.lastSync === undefined ? {} : { lastSync: props.lastSync }),
+          by,
+          toggled,
+          now,
+        },
+      ),
+    [config.targets, diffs, props.lastSync, by, toggled, now],
   );
   const [cursor, setCursor] = useState(0);
 
@@ -227,25 +554,57 @@ export function Diff(props: DiffProps): React.ReactElement {
   // a word, so the list must be told how many lines it may actually use.
   const chrome = 2 + 1 + 4;
   const room = Math.max(3, (props.height ?? 40) - chrome);
-  const last = Math.max(0, rows.length - 1);
+  const selectable = useMemo(() => selectableRows(rows), [rows]);
+  const at = snapTo(selectable, cursor);
+  const nth = selectable.indexOf(at);
+  const here = rows[at];
+  /** Steps `n` selectable rows from where the cursor actually is. */
+  const step = (n: number): void => {
+    const to = selectable[Math.max(0, Math.min(selectable.length - 1, nth + n))];
+    if (to !== undefined) setCursor(to);
+  };
 
   useInput((input, key) => {
     if (key.escape || input === "e") return onClose();
-    if (key.upArrow || input === "k") setCursor((c) => Math.max(0, c - 1));
-    else if (key.downArrow || input === "j") setCursor((c) => Math.min(last, c + 1));
-    else if (key.pageUp || input === "u") setCursor((c) => Math.max(0, c - room));
-    else if (key.pageDown || input === " " || input === "d") setCursor((c) => Math.min(last, c + room));
+    if (key.upArrow || input === "k") step(-1);
+    else if (key.downArrow || input === "j") step(1);
+    else if (key.pageUp || input === "u") step(-room);
+    else if (key.pageDown || input === " " || input === "d") step(room);
     else if (input === "g") setCursor(0);
-    else if (input === "G") setCursor(last);
+    else if (input === "G") setCursor(rows.length);
+    else if (key.return && here?.kind === "group") {
+      // A flip is recorded, not a state. A group's default is a property of its
+      // size, so a re-check that grows one past the threshold still finds it
+      // closed, and a reader who opened it still finds it open.
+      const id = here.id;
+      // The cursor stays on the group it opened, which is where the reader is
+      // looking; the rows it reveals appear below it.
+      setCursor(at);
+      setToggled((t) => {
+        const next = new Set(t);
+        if (!next.delete(id)) next.add(id);
+        return next;
+      });
+    } else if (input === "b") {
+      // The cursor indexes rows that are about to be rebuilt, so it returns to
+      // the top rather than pointing at an unrelated file.
+      setBy((b) => GROUP_BY[(GROUP_BY.indexOf(b) + 1) % GROUP_BY.length]!);
+      setCursor(0);
+    }
   });
 
-  const { start, end } = windowFor(cursor, rows.length, room);
+  const { start, end } = windowFor(at, rows.length, room);
   const shown = rows.slice(start, end);
-  const entryCount = rows.filter((r) => r.kind === "entry").length;
+  // Counted from the record, not from the rows on screen. Counting rows was
+  // right while every difference was one row and became a lie the moment a
+  // group could be closed: five hundred collapsed files reported "0
+  // differences", which is the opposite of what the screen exists to say.
+  const entryCount = [...diffs.values()].reduce((n, d) => n + (d?.entries.length ?? 0), 0);
+  const shownOf = `${entryCount} ${entryCount === 1 ? "difference" : "differences"}`;
   const position =
     rows.length <= room
-      ? `${entryCount} ${entryCount === 1 ? "difference" : "differences"}`
-      : `${start + 1}–${end} of ${rows.length}   [↑↓] scroll  [g]/[G] ends`;
+      ? shownOf
+      : `${shownOf}   ${start + 1}–${end} of ${rows.length}   [↑↓] scroll  [g]/[G] ends`;
 
   return (
     <Screen
@@ -258,7 +617,13 @@ export function Diff(props: DiffProps): React.ReactElement {
           <Rule width={width} theme={theme} char="·" />
           <Text color={theme.dim}>{"  " + legendLine(width)}</Text>
           <Text color={theme.dim}>{"  " + truncate(position, width - 2)}</Text>
-          <Text color={theme.dim}>{"  [esc] back   nothing here deletes anything"}</Text>
+          <Text color={theme.dim}>
+            {"  " +
+              truncate(
+                `[esc] back   [enter] open a group   [b] by ${by}   nothing here deletes anything`,
+                width - 2,
+              )}
+          </Text>
         </Box>
       }
     >
@@ -266,12 +631,32 @@ export function Diff(props: DiffProps): React.ReactElement {
         <Text color={theme.dim}>{"  no destinations configured"}</Text>
       ) : null}
       {shown.map((r, i) => {
-        const key = `${start + i}`;
+        const row = start + i;
+        const key = `${row}`;
         if (r.kind === "blank") return <Text key={key}> </Text>;
-        if (r.kind === "note") return <Text key={key} color={theme.rule}>{"    " + r.text}</Text>;
-        if (r.kind === "magnitude") {
+        if (r.kind === "note")
           return (
-            <Text key={key} color={theme.dim}>{"  " + truncate(r.text, width - 2)}</Text>
+            <Text key={key} color={theme.rule}>
+              {"    " + r.text}
+            </Text>
+          );
+        if (r.kind === "magnitude" || r.kind === "lag") {
+          return (
+            <Text key={key} color={theme.dim}>
+              {"  " + truncate(r.text, width - 2)}
+            </Text>
+          );
+        }
+        if (r.kind === "verdict") {
+          return (
+            <Text key={key} color={r.alarm ? theme.missing : theme.ink}>
+              {"  " + truncate(r.text, width - 2)}
+            </Text>
+          );
+        }
+        if (r.kind === "group") {
+          return (
+            <Group key={key} row={r} theme={theme} width={width} now={now} selected={row === at} />
           );
         }
         if (r.kind === "header") {
@@ -284,7 +669,19 @@ export function Diff(props: DiffProps): React.ReactElement {
             </Box>
           );
         }
-        return <Entry key={key} entry={r.entry} theme={theme} width={width} />;
+        return (
+          <Entry
+            key={key}
+            entry={r.entry}
+            theme={theme}
+            width={width}
+            now={now}
+            indent={r.indent}
+            strip={r.strip}
+            showFlags={r.showFlags}
+            selected={row === at}
+          />
+        );
       })}
     </Screen>
   );
@@ -296,14 +693,22 @@ export function diffText(
   unit: string,
   diffs: ReadonlyMap<string, Diff | null>,
   now: number,
+  lastSync?: ReadonlyMap<string, number | null>,
 ): string {
   const out: string[] = [`differences · ${unit}`, ""];
   for (const t of config.targets) {
     const diff = diffs.get(t.name) ?? null;
     out.push(`${t.name}  ${summaryLine(diff, now)}`);
+    const lag = lagLine(diff, now);
+    if (lag !== null) out.push(`  ${lag}`);
+    if (diff !== null) {
+      const at = lastSync?.get(t.name) ?? null;
+      for (const line of syncLine(splitBySync(diff, at), now)) out.push(`  ${line}`);
+    }
     for (const e of diff?.entries ?? []) {
       const size = !e.sized ? "—" : e.dir ? "dir" : bytes(e.bytes);
-      out.push(`  ${GLYPH[e.kind]} ${e.name}  ${size}  ${e.flags}`);
+      const when = e.mtime === undefined ? "" : `  ${day(e.mtime, now)}`;
+      out.push(`  ${GLYPH[e.kind]} ${e.name}  ${size}${when}  ${e.flags}`);
     }
     if ((diff?.truncated ?? 0) > 0) out.push(`  … ${diff!.truncated} more not recorded`);
     out.push("");
@@ -312,4 +717,4 @@ export function diffText(
 }
 
 // Kept for the tests, which assert the legend and the listing agree.
-export { LABEL as DIFF_LABELS, GLYPH as DIFF_GLYPHS, ORDER as DIFF_ORDER, displayWidth };
+export { LABEL as DIFF_LABELS, GLYPH as DIFF_GLYPHS, ORDER as DIFF_ORDER, displayWidth, folderOf };

--- a/test/diff.test.tsx
+++ b/test/diff.test.tsx
@@ -204,6 +204,7 @@ describe("the differences screen", () => {
     diffs: ReadonlyMap<string, DiffRecord | null>,
     width = 92,
     height?: number,
+    by?: "folder" | "type" | "age" | "flat",
   ): string => {
     const { lastFrame } = render(
       <Diff
@@ -213,6 +214,7 @@ describe("the differences screen", () => {
         theme={THEMES.ansi}
         width={width}
         {...(height === undefined ? {} : { height })}
+        {...(by === undefined ? {} : { by })}
         now={NOW}
         onClose={() => {}}
       />,
@@ -241,8 +243,20 @@ describe("the differences screen", () => {
     expect(out).toContain("edited.jpg");
   });
 
-  test("it shows rsync's itemize string next to each file", () => {
+  test("it shows rsync's itemize string, which is the evidence for the claim", () => {
     expect(frame(both)).toContain(">f+++++++++");
+  });
+
+  test("a group states the itemize string its rows gave up", () => {
+    // The column moved onto the header when every row shares one string. Moving
+    // it is a change of place; dropping it would be a change of claim.
+    const many = Array.from({ length: 40 }, (_, i) =>
+      item(`>f+++++++++|100|shoot/file-${String(i).padStart(3, "0")}.jpg`),
+    );
+    const d = buildDiff("holiday-2024", "external", "quick", many, { ts: NOW });
+    const out = frame(new Map([["external", d], ["NAS", null]]), 120, 24);
+    expect(out).toContain(">f+++++++++");
+    expect(out).toContain("all created new");
   });
 
   test("it offers nothing that deletes, and says so", () => {
@@ -281,9 +295,38 @@ describe("the differences screen", () => {
       item(`>f+++++++++|100|file-${String(i).padStart(3, "0")}.jpg`),
     );
     const d = buildDiff("holiday-2024", "external", "quick", many, { ts: NOW });
-    const out = frame(new Map([["external", d], ["NAS", null]]), 92, 24);
+    const out = frame(new Map([["external", d], ["NAS", null]]), 92, 24, "flat");
     expect(out).toMatch(/\d+–\d+ of \d+/);
     expect(out).toContain("scroll");
+  });
+
+  test("hundreds of files collapse to one line that describes the set", () => {
+    // The screen this replaces drew 200 rows carrying a name and a size each.
+    // Everything a reader wanted — how many, how big, of what — was a property
+    // of the set and appeared nowhere.
+    const many = Array.from({ length: 200 }, (_, i) =>
+      item(`>f+++++++++|100000|shoot/file-${String(i).padStart(3, "0")}.jpg`),
+    );
+    const d = buildDiff("holiday-2024", "external", "quick", many, { ts: NOW });
+    const out = frame(new Map([["external", d], ["NAS", null]]), 120, 24);
+    expect(out).toContain("200 files");
+    expect(out).toContain(".jpg 200");
+    expect(out).not.toContain("file-000.jpg");
+  });
+
+  test("the count is of differences found, not of rows currently drawn", () => {
+    // A collapsed group reported "0 differences" — the opposite of the point.
+    const many = Array.from({ length: 200 }, (_, i) =>
+      item(`>f+++++++++|100|shoot/file-${String(i).padStart(3, "0")}.jpg`),
+    );
+    const d = buildDiff("holiday-2024", "external", "quick", many, { ts: NOW });
+    expect(frame(new Map([["external", d], ["NAS", null]]), 120, 24)).toContain("200 differences");
+  });
+
+  test("a group of one is drawn as the file, not as a heading over it", () => {
+    const out = frame(both);
+    expect(out).toContain("new.jpg");
+    expect(out).not.toContain("1 file ·");
   });
 
   test("the summary never wraps, which would cost a line of the listing", () => {
@@ -296,14 +339,19 @@ describe("the differences screen", () => {
     expect(orphan, `wrapped: ${orphan}`).toBeUndefined();
   });
 
-  test("differences are ordered worst first", () => {
+  test("differences are ordered by what is surprising, not by what is common", () => {
+    // Not the legend's order. Ranking by kind put routine creations above
+    // everything else, so a folder with a 504-file backlog and one file whose
+    // attributes differed showed the interesting row at position 505 of a
+    // windowed list — which is to say nowhere. A backlog is the least
+    // surprising thing on the screen and now sorts below the rest.
     const d = buildDiff("holiday-2024", "external", "quick", [EXTRA, META, CHANGED, NEW_FILE], {
       ts: NOW,
     });
     const out = frame(new Map([["external", d], ["NAS", null]]));
-    expect(out.indexOf("new.jpg")).toBeLessThan(out.indexOf("edited.jpg"));
     expect(out.indexOf("edited.jpg")).toBeLessThan(out.indexOf("touched.jpg"));
-    expect(out.indexOf("touched.jpg")).toBeLessThan(out.indexOf("gone.jpg"));
+    expect(out.indexOf("touched.jpg")).toBeLessThan(out.indexOf("new.jpg"));
+    expect(out.indexOf("new.jpg")).toBeLessThan(out.indexOf("gone.jpg"));
   });
 
   test("the clipboard text carries the same facts as the screen", () => {
@@ -366,7 +414,9 @@ describe("the differences list scrolls", () => {
     item(`>f+++++++++|1000000|file-${String(i).padStart(3, "0")}.jpg`),
   );
   const big = buildDiff("holiday-2024", "external", "deep", many, { ts: NOW });
-  const rows = diffRows(["external", "NAS"], new Map([["external", big], ["NAS", null]]));
+  const rows = diffRows(["external", "NAS"], new Map([["external", big], ["NAS", null]]), {
+    by: "flat",
+  });
 
   test("every entry is reachable, not just the first screenful", () => {
     // The regression this replaces: a fixed dozen shown and the other 490
@@ -405,7 +455,7 @@ describe("the differences list scrolls", () => {
   test("arrow keys move through the list", async () => {
     const { stdin, lastFrame } = render(
       <Diff config={config} unit="holiday-2024" diffs={new Map([["external", big], ["NAS", null]])}
-        theme={THEMES.ansi} width={92} height={20} now={NOW} onClose={() => {}} />,
+        by="flat" theme={THEMES.ansi} width={92} height={20} now={NOW} onClose={() => {}} />,
     );
     const wait = (): Promise<void> => new Promise((r) => setTimeout(r, 40));
     const before = plain(lastFrame());

--- a/test/difference-shape.test.tsx
+++ b/test/difference-shape.test.tsx
@@ -1,0 +1,557 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseItemizeLine, parseMtime } from "../src/itemize.ts";
+import {
+  ageAgainstSync,
+  ageBucket,
+  buildDiff,
+  folderOf,
+  groupDiff,
+  splitBySync,
+  typeOf,
+  type DiffEntry,
+} from "../src/diff.ts";
+import { lastSyncAt } from "../src/state.ts";
+import { makeFixtureDir, removeFixtureDir } from "./helpers.ts";
+import { render } from "ink-testing-library";
+import {
+  Diff,
+  diffRows,
+  groupDetail,
+  lagLine,
+  selectableRows,
+  snapTo,
+  syncLine,
+} from "../src/tui/Diff.tsx";
+import { THEMES } from "../src/tui/theme.ts";
+
+/**
+ * The differences screen could not answer the question it existed for: whether
+ * a missing file is a backlog or a gap. Nothing recorded when a file was
+ * written, so every difference looked alike and 504 of them looked like one
+ * undifferentiated wall. These cover the time dimension that fixes that.
+ */
+
+const DAY = 86_400_000;
+const NOW = Date.UTC(2024, 1, 20, 12, 0, 0);
+
+const entry = (over: Partial<DiffEntry> = {}): DiffEntry => ({
+  kind: "new",
+  name: "a.jpg",
+  bytes: 100,
+  flags: ">f+++++++++",
+  dir: false,
+  sized: true,
+  ...over,
+});
+
+describe("rsync's %M gives every difference a date", () => {
+  test("a timestamp field is read as local time", () => {
+    const ms = parseMtime("2024/02/14-09:30:00");
+    expect(ms).not.toBeNull();
+    const d = new Date(ms!);
+    expect([d.getFullYear(), d.getMonth(), d.getDate(), d.getHours()]).toEqual([2024, 1, 14, 9]);
+  });
+
+  test("the epoch means no timestamp, not the first second of 1970", () => {
+    // Every `*deleting` line carries it: there is no source file to date.
+    expect(parseMtime("1970/01/01-00:00:00")).toBeNull();
+    expect(parseItemizeLine("*deleting  |0|1969/12/31-16:00:00|old/a.jpg")!.mtime).toBeNull();
+  });
+
+  test("a four-field line yields the date and the name", () => {
+    const it = parseItemizeLine(">f+++++++++|65103872|2024/02/14-09:30:00|IMG_4822.CR3")!;
+    expect(it.name).toBe("IMG_4822.CR3");
+    expect(it.bytes).toBe(65_103_872);
+    expect(it.mtime).not.toBeNull();
+  });
+
+  test("a line written before %M was asked for still parses, undated", () => {
+    // A stored log replayed after an upgrade must not read as a parse failure.
+    const it = parseItemizeLine(">f+++++++++|10|a/b/c.txt")!;
+    expect(it.name).toBe("a/b/c.txt");
+    expect(it.mtime).toBeNull();
+  });
+
+  test("a name containing the delimiter survives both formats", () => {
+    // rsync does not escape `|`, so the timestamp's shape is what separates a
+    // third field from the first pipe inside a filename.
+    expect(parseItemizeLine(">f+++++++++|10|weird|name.txt")!.name).toBe("weird|name.txt");
+    expect(parseItemizeLine(">f+++++++++|10|2024/02/14-09:30:00|weird|name.txt")!.name).toBe(
+      "weird|name.txt",
+    );
+  });
+
+  test("the date reaches the stored diff", () => {
+    const items = [parseItemizeLine(">f+++++++++|10|2024/02/14-09:30:00|a.jpg")!];
+    expect(buildDiff("u", "t", "quick", items).entries[0]!.mtime).not.toBeUndefined();
+  });
+});
+
+describe("when a sync last landed", () => {
+  const made: string[] = [];
+  const write = (body: string): string => {
+    const dir = makeFixtureDir("history");
+    made.push(dir);
+    const file = join(dir, "history.jsonl");
+    writeFileSync(file, body);
+    return file;
+  };
+  const history = (lines: readonly object[]): string =>
+    write(lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  afterAll(() => {
+    for (const d of made) removeFixtureDir(d);
+  });
+
+  test("the newest successful sync for that unit and destination wins", () => {
+    const f = history([
+      { ts: 100, unit: "u", target: "ext", argv: [], exitCode: 0 },
+      { ts: 300, unit: "u", target: "ext", argv: [], exitCode: 0 },
+      { ts: 200, unit: "u", target: "ext", argv: [], exitCode: 0 },
+    ]);
+    expect(lastSyncAt("u", "ext", f)).toBe(300);
+  });
+
+  test("another unit or another destination is not this one's sync", () => {
+    const f = history([
+      { ts: 900, unit: "other", target: "ext", argv: [], exitCode: 0 },
+      { ts: 800, unit: "u", target: "nas", argv: [], exitCode: 0 },
+      { ts: 100, unit: "u", target: "ext", argv: [], exitCode: 0 },
+    ]);
+    expect(lastSyncAt("u", "ext", f)).toBe(100);
+  });
+
+  test("a failed run is not a sync that landed", () => {
+    const f = history([
+      { ts: 100, unit: "u", target: "ext", argv: [], exitCode: 0 },
+      { ts: 500, unit: "u", target: "ext", argv: [], exitCode: 23 },
+    ]);
+    expect(lastSyncAt("u", "ext", f)).toBe(100);
+  });
+
+  test("exit 24 counts, as it does everywhere else", () => {
+    // Files vanishing mid-run is routine on a live archive and does not mean
+    // nothing was copied.
+    const f = history([{ ts: 500, unit: "u", target: "ext", argv: [], exitCode: 24 }]);
+    expect(lastSyncAt("u", "ext", f)).toBe(500);
+  });
+
+  test("a torn last line does not hide every sync before it", () => {
+    const good = JSON.stringify({ ts: 7, unit: "u", target: "ext", argv: [], exitCode: 0 });
+    expect(lastSyncAt("u", "ext", write(`${good}\n{"ts":8,`))).toBe(7);
+  });
+
+  test("never synced reads as never, not as the epoch", () => {
+    const dir = makeFixtureDir("history");
+    made.push(dir);
+    expect(lastSyncAt("u", "ext", join(dir, "no-history-here.jsonl"))).toBeNull();
+  });
+});
+
+describe("which side of the last sync a missing file falls on", () => {
+  const LAST = NOW - 7 * DAY;
+
+  test("written since the sync is a backlog; written before it is a gap", () => {
+    expect(ageAgainstSync(entry({ mtime: NOW - DAY }), LAST)).toBe("since");
+    expect(ageAgainstSync(entry({ mtime: NOW - 30 * DAY }), LAST)).toBe("before");
+  });
+
+  test("no date and no sync are both undated, never guessed", () => {
+    expect(ageAgainstSync(entry(), LAST)).toBe("undated");
+    expect(ageAgainstSync(entry({ mtime: NOW }), null)).toBe("undated");
+  });
+
+  test("only files a sync would copy are split", () => {
+    // An extra is at the destination and an attribute difference is at both;
+    // neither is waiting to be copied, so neither belongs in the count.
+    const d = buildDiff("u", "t", "quick", [], {});
+    const withEntries = {
+      ...d,
+      entries: [
+        entry({ mtime: NOW - DAY }),
+        entry({ kind: "changed", name: "b.jpg", mtime: NOW - 30 * DAY }),
+        entry({ kind: "extra", name: "c.jpg", sized: false }),
+        entry({ kind: "metadata", name: "d.jpg", mtime: NOW - 30 * DAY }),
+      ],
+    };
+    expect(splitBySync(withEntries, LAST)).toEqual({
+      since: 1,
+      before: 1,
+      undated: 0,
+      lastSyncTs: LAST,
+    });
+  });
+
+  test("both sides of the sync are one finding, on one line", () => {
+    // Two lines each opening with a number read as two separate findings. It is
+    // one finding with a split in it.
+    const lines = syncLine({ since: 498, before: 6, undated: 0, lastSyncTs: LAST }, NOW);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("6 predate");
+    expect(lines[0]).toContain("498 after");
+  });
+
+  test("the totals above are not restated here", () => {
+    // The summary line already says 504. The only new fact is where the line
+    // falls, and a screen this narrow cannot afford to say anything twice.
+    expect(syncLine({ since: 498, before: 6, undated: 0, lastSyncTs: LAST }, NOW)[0]).not.toContain(
+      "504",
+    );
+  });
+
+  test("the split line stays inside a narrow window", () => {
+    for (const split of [
+      { since: 498, before: 6, undated: 2, lastSyncTs: LAST },
+      { since: 0, before: 504, undated: 0, lastSyncTs: LAST },
+      { since: 504, before: 0, undated: 0, lastSyncTs: LAST },
+    ]) {
+      const line = syncLine(split, NOW)[0]!;
+      expect(line.length, line).toBeLessThanOrEqual(76);
+    }
+  });
+
+  test("the gap is hedged, because an import preserves old dates", () => {
+    // A preserved mtime can make a genuinely new file look old, so the wording
+    // says which side of the line a file falls on and claims nothing further.
+    const line = syncLine({ since: 0, before: 6, undated: 0, lastSyncTs: LAST }, NOW)[0]!;
+    expect(line).toContain("imports preserve dates");
+    expect(line).not.toContain("failed");
+  });
+
+  test("the caveat is dropped when nothing is on the older side of the line", () => {
+    // It explains a number that is not on screen; unqualified, it is filler.
+    expect(syncLine({ since: 6, before: 0, undated: 0, lastSyncTs: LAST }, NOW)[0]).not.toContain(
+      "imports",
+    );
+  });
+
+  test("before any sync has run, nothing is called a gap", () => {
+    const lines = syncLine({ since: 0, before: 0, undated: 9, lastSyncTs: null }, NOW).join("\n");
+    expect(lines).toContain("no sync has run here yet");
+    expect(lines).not.toContain("predate");
+  });
+
+  test("nothing pending says nothing at all", () => {
+    expect(syncLine({ since: 0, before: 0, undated: 0, lastSyncTs: LAST }, NOW)).toEqual([]);
+  });
+});
+
+describe("how far behind the destination is", () => {
+  const fp = (ms: number) => ({ nfiles: 1, bytes: 1, maxMtimeNs: String(BigInt(ms) * 1_000_000n) });
+  const diff = (here: number, there: number) => ({
+    ...buildDiff("u", "t", "quick", []),
+    sourceHolds: fp(here),
+    targetHolds: fp(there),
+  });
+
+  test("it names both dates and the gap between them", () => {
+    const line = lagLine(diff(NOW, NOW - 11 * DAY))!;
+    expect(line).toContain("newest here");
+    expect(line).toContain("there");
+    expect(line).toContain("11 days behind");
+    expect(line.length, line).toBeLessThanOrEqual(76);
+  });
+
+  test("one day is not 1 days", () => {
+    expect(lagLine(diff(NOW, NOW - DAY))).toContain("1 day behind");
+  });
+
+  test("a destination holding the newest file is not reported as behind", () => {
+    expect(lagLine(diff(NOW, NOW))).not.toContain("behind");
+  });
+
+  test("a record without both fingerprints says nothing rather than guessing", () => {
+    expect(lagLine(buildDiff("u", "t", "quick", []))).toBeNull();
+    expect(lagLine(null)).toBeNull();
+  });
+
+  test("a hand-edited fingerprint does not crash the screen", () => {
+    const d = { ...buildDiff("u", "t", "quick", []), sourceHolds: { nfiles: 1, bytes: 1, maxMtimeNs: "banana" }, targetHolds: fp(NOW) };
+    expect(lagLine(d)).toBeNull();
+  });
+});
+
+describe("the listing has a shape", () => {
+  const shoot = (dir: string, n: number, ext: string, ts: number): DiffEntry[] =>
+    Array.from({ length: n }, (_, i) =>
+      entry({ name: `${dir}/DSC_${String(1000 + i)}${ext}`, mtime: ts, bytes: 6_000_000 }),
+    );
+
+  test("folders are read off the names", () => {
+    expect(folderOf("2024/02-hokkaido/DSC_1895.NEF")).toBe("2024/02-hokkaido");
+    expect(folderOf("top.jpg")).toBe("");
+  });
+
+  test("types are read off the names, case-folded", () => {
+    expect(typeOf(entry({ name: "a/DSC_1.NEF" }))).toBe(".nef");
+    expect(typeOf(entry({ name: "a/Makefile" }))).toBe("");
+    expect(typeOf(entry({ name: "a/dir", dir: true }))).toBe("");
+  });
+
+  test("age buckets are coarse enough that a shoot lands in one", () => {
+    expect(ageBucket(NOW - 3600_000, NOW)).toBe("today");
+    expect(ageBucket(NOW - 3 * DAY, NOW)).toBe("this week");
+    expect(ageBucket(NOW - 300 * DAY, NOW)).toBe("this year");
+    expect(ageBucket(NOW - 800 * DAY, NOW)).toBe("older");
+    expect(ageBucket(undefined, NOW)).toBe("undated");
+  });
+
+  test("one import becomes one group, not four hundred rows", () => {
+    const entries = [
+      ...shoot("2024/02-hokkaido", 200, ".NEF", NOW - DAY),
+      ...shoot("2024/02-hokkaido", 200, ".JPG", NOW - DAY),
+    ];
+    const groups = groupDiff(entries, "folder", NOW - 30 * DAY, NOW);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.entries).toHaveLength(400);
+    expect(groups[0]!.types.map(([e]) => e).sort()).toEqual([".jpg", ".nef"]);
+  });
+
+  test("a group states how many, how big, of what and from when", () => {
+    const groups = groupDiff(shoot("shoot", 30, ".NEF", NOW - DAY), "folder", NOW - 30 * DAY, NOW);
+    const detail = groupDetail(groups[0]!);
+    expect(detail).toContain("30 files");
+    expect(detail).toContain(".nef 30");
+    expect(detail).toContain("all created new");
+  });
+
+  test("a shared itemize string is stated once, not thirty times", () => {
+    const groups = groupDiff(shoot("shoot", 30, ".NEF", NOW - DAY), "folder", NOW - 30 * DAY, NOW);
+    expect(groups[0]!.flags).toBe(">f+++++++++");
+    expect(groupDetail(groups[0]!)).toContain(">f+++++++++");
+  });
+
+  test("a group whose rows disagree keeps the column on the rows", () => {
+    const mixed = [entry({ name: "d/a.jpg" }), entry({ name: "d/b.jpg", flags: ">f.st......" })];
+    expect(groupDiff(mixed, "folder", null, NOW)[0]!.flags).toBeNull();
+  });
+
+  test("files that predate the sync are their own group, not buried in the backlog", () => {
+    // The whole point: six files that should already be there cannot hide
+    // inside five hundred that are merely waiting.
+    const entries = [
+      ...shoot("2024/02-hokkaido", 400, ".NEF", NOW - DAY),
+      ...shoot("2023/12-family", 6, ".JPG", NOW - 300 * DAY),
+    ];
+    const groups = groupDiff(entries, "folder", NOW - 30 * DAY, NOW);
+    expect(groups[0]!.before).toBe(true);
+    expect(groups[0]!.entries).toHaveLength(6);
+    expect(groupDetail(groups[0]!)).toContain("predates the last sync");
+  });
+
+  test("the group and the split line use one word for one idea", () => {
+    // "older than" on the group and "predate" on the line above it read as two
+    // different findings about the same six files.
+    const entries = shoot("old", 3, ".JPG", NOW - 300 * DAY);
+    const detail = groupDetail(groupDiff(entries, "folder", NOW - 30 * DAY, NOW)[0]!, NOW);
+    const line = syncLine({ since: 0, before: 3, undated: 0, lastSyncTs: NOW - 30 * DAY }, NOW)[0]!;
+    expect(detail).toContain("predates");
+    expect(line).toContain("predate");
+  });
+
+  test("a gap outranks a backlog however much larger the backlog is", () => {
+    const entries = [
+      ...shoot("bulk", 500, ".NEF", NOW - DAY),
+      ...shoot("old", 1, ".JPG", NOW - 300 * DAY),
+    ];
+    const [first] = groupDiff(entries, "folder", NOW - 30 * DAY, NOW);
+    expect(first!.label).toBe("old");
+  });
+
+  test("a content difference outranks a backlog, whatever the legend's order says", () => {
+    const entries = [
+      ...shoot("bulk", 500, ".NEF", NOW - DAY),
+      entry({ kind: "changed", name: "x/edited.jpg", flags: ">f.st......", mtime: NOW - DAY }),
+    ];
+    const [first] = groupDiff(entries, "folder", NOW - 30 * DAY, NOW);
+    expect(first!.kind).toBe("changed");
+  });
+
+  test("extras sink to the bottom, since syncy never acts on them", () => {
+    const entries = [
+      entry({ kind: "extra", name: "x/gone.jpg", sized: false }),
+      ...shoot("bulk", 20, ".NEF", NOW - DAY),
+    ];
+    const groups = groupDiff(entries, "folder", NOW - 30 * DAY, NOW);
+    expect(groups[groups.length - 1]!.kind).toBe("extra");
+  });
+
+  test("kinds never share a group, because they are unrelated facts", () => {
+    const entries = [
+      entry({ name: "d/a.jpg", mtime: NOW - DAY }),
+      entry({ kind: "changed", name: "d/b.jpg", flags: ">f.st......", mtime: NOW - DAY }),
+    ];
+    expect(groupDiff(entries, "folder", NOW - 30 * DAY, NOW)).toHaveLength(2);
+  });
+
+  test("grouping by type cuts across folders", () => {
+    const entries = [
+      ...shoot("a", 5, ".NEF", NOW - DAY),
+      ...shoot("b", 5, ".NEF", NOW - DAY),
+      ...shoot("b", 3, ".JPG", NOW - DAY),
+    ];
+    const groups = groupDiff(entries, "type", NOW - 30 * DAY, NOW);
+    expect(groups.map((g) => g.label).sort()).toEqual([".jpg", ".nef"]);
+    expect(groups.find((g) => g.label === ".nef")!.entries).toHaveLength(10);
+  });
+
+  test("grouping by age puts a shoot in one bucket", () => {
+    const entries = [
+      ...shoot("a", 5, ".NEF", NOW - 2 * DAY),
+      ...shoot("b", 5, ".NEF", NOW - 200 * DAY),
+    ];
+    const labels = groupDiff(entries, "age", null, NOW).map((g) => g.label);
+    expect(labels).toContain("this week");
+    expect(labels).toContain("this year");
+  });
+
+  test("every entry lands in exactly one group, whatever the grouping", () => {
+    const entries = [
+      ...shoot("a", 7, ".NEF", NOW - 2 * DAY),
+      ...shoot("b", 4, ".JPG", NOW - 200 * DAY),
+      entry({ kind: "extra", name: "c/gone.jpg", sized: false }),
+    ];
+    for (const by of ["folder", "type", "age"] as const) {
+      const groups = groupDiff(entries, by, NOW - 30 * DAY, NOW);
+      const total = groups.reduce((n, g) => n + g.entries.length, 0);
+      expect(total, `by ${by}`).toBe(entries.length);
+    }
+  });
+});
+
+describe("opening a group and changing the grouping", () => {
+  const plain = (s: string | undefined): string => (s ?? "").replace(/\[[0-9;]*m/g, "");
+  const wait = (): Promise<void> => new Promise((r) => setTimeout(r, 40));
+  const config = {
+    source: "/src",
+    targets: [{ name: "ext", path: "/ext", required: true, modifyWindow: 0, flagsDrop: [] }],
+    exclude: [],
+  } as never;
+
+  const many = Array.from({ length: 60 }, (_, i) =>
+    entry({ name: `shoot/DSC_${String(1000 + i)}.NEF`, mtime: NOW - DAY, bytes: 17_000_000 }),
+  );
+  const diff = { ...buildDiff("u", "ext", "quick", []), entries: many };
+
+  const screen = () =>
+    render(
+      <Diff
+        config={config}
+        unit="u"
+        diffs={new Map([["ext", diff]])}
+        lastSync={new Map([["ext", NOW - 30 * DAY]])}
+        theme={THEMES.ansi}
+        width={110}
+        height={30}
+        now={NOW}
+        onClose={() => {}}
+      />,
+    );
+
+  test("a group past the threshold opens closed, and enter opens it", async () => {
+    const { stdin, lastFrame } = screen();
+    expect(plain(lastFrame())).not.toContain("DSC_1000.NEF");
+    stdin.write("j"); // off the destination header, onto the group
+    await wait();
+    stdin.write("j");
+    await wait();
+    stdin.write("\r");
+    await wait();
+    expect(plain(lastFrame())).toContain("DSC_1000.NEF");
+  });
+
+  test("[b] cycles the grouping and says which one is showing", async () => {
+    const { stdin, lastFrame } = screen();
+    expect(plain(lastFrame())).toContain("by folder");
+    stdin.write("b");
+    await wait();
+    expect(plain(lastFrame())).toContain("by type");
+    stdin.write("b");
+    await wait();
+    expect(plain(lastFrame())).toContain("by age");
+    stdin.write("b");
+    await wait();
+    const flat = plain(lastFrame());
+    expect(flat).toContain("by flat");
+    // Flat is the original listing: one row per file, no headers.
+    expect(flat).toContain("DSC_1000.NEF");
+  });
+
+  test("the grouping wraps back round rather than sticking at the end", async () => {
+    const { stdin, lastFrame } = screen();
+    for (let i = 0; i < 4; i++) {
+      stdin.write("b");
+      await wait();
+    }
+    expect(plain(lastFrame())).toContain("by folder");
+  });
+});
+
+describe("the cursor lands only on things that can show they are selected", () => {
+  const plain = (s: string | undefined): string => (s ?? "").replace(/\[[0-9;]*m/g, "");
+  const wait = (): Promise<void> => new Promise((r) => setTimeout(r, 40));
+  const config = {
+    source: "/src",
+    targets: [{ name: "ext", path: "/ext", required: true, modifyWindow: 0, flagsDrop: [] }],
+    exclude: [],
+  } as never;
+
+  const many = Array.from({ length: 40 }, (_, i) =>
+    entry({ name: `shoot/DSC_${String(1000 + i)}.NEF`, mtime: NOW - DAY, bytes: 17_000_000 }),
+  );
+  const diff = {
+    ...buildDiff("u", "ext", "quick", []),
+    entries: [...many, entry({ name: "loose.jpg", mtime: NOW - DAY })],
+    sourceHolds: { nfiles: 41, bytes: 1, maxMtimeNs: String(BigInt(NOW) * 1_000_000n) },
+    targetHolds: { nfiles: 0, bytes: 0, maxMtimeNs: String(BigInt(NOW - 9 * DAY) * 1_000_000n) },
+  };
+  const rows = diffRows(["ext"], new Map([["ext", diff]]), {
+    lastSync: new Map([["ext", NOW - 30 * DAY]]),
+    now: NOW,
+  });
+
+  test("statements are not targets", () => {
+    // The header, the totals, the lag line and the sync split are things the
+    // screen says, not things a cursor visits.
+    const kinds = new Set(selectableRows(rows).map((i) => rows[i]!.kind));
+    expect([...kinds].sort()).toEqual(["entry", "group"]);
+  });
+
+  test("there is prose above the first selectable row", () => {
+    // Which is exactly why the cursor used to look dead: several presses moved
+    // through lines that had no way to show they were selected.
+    expect(selectableRows(rows)[0]).toBeGreaterThan(0);
+  });
+
+  test("a cursor left on a rebuilt list snaps forward, never off the end", () => {
+    const sel = selectableRows(rows);
+    expect(sel).toContain(snapTo(sel, 0));
+    expect(snapTo(sel, 0)).toBe(sel[0]!);
+    expect(snapTo(sel, rows.length + 99)).toBe(sel[sel.length - 1]!);
+    expect(snapTo([], 5)).toBe(0);
+  });
+
+  test("one press moves the selection, with nothing dead in between", async () => {
+    const { stdin, lastFrame } = render(
+      <Diff
+        config={config}
+        unit="u"
+        diffs={new Map([["ext", diff]])}
+        lastSync={new Map([["ext", NOW - 30 * DAY]])}
+        theme={THEMES.ansi}
+        width={110}
+        height={30}
+        now={NOW}
+        onClose={() => {}}
+      />,
+    );
+    const marked = (s: string): string =>
+      s.split("\n").find((l) => l.trimStart().startsWith("»")) ?? "";
+    const first = marked(plain(lastFrame()));
+    expect(first, "something is marked before any key is pressed").not.toBe("");
+    stdin.write("j");
+    await wait();
+    expect(marked(plain(lastFrame()))).not.toBe(first);
+  });
+});


### PR DESCRIPTION
`504 not at destination` and 504 rows saying so are the same number twice. Each row carried a name and a size under an itemize column that repeated `>f+++++++++` five hundred times — a creation has nothing else to say, so `explainFlags` returns nothing for one. The single file whose attributes differed sorted to row 505 of a windowed list, which is to say nowhere.

Worse, the screen could not answer the question it exists for. `DiffEntry` had no time dimension, so a file waiting on the next sync and a file that should already be at the destination looked identical.

### Before / after

```
before:
  External   504 not at destination · 1 attributes differ · 5.8 gb to copy · quick check 1d ago
    + DSC_0122.JPG      6.1 mb   >f+++++++++
    + DSC_0122.NEF       17 mb   >f+++++++++
    + DSC_0123.JPG       5.7 mb  >f+++++++++
    …500 more…

after:
  External   418 not at destination · 1 attributes differ · 4.5 gb to copy · quick check 1d ago
  source 935 files · 13 gb   destination 431 files · 7.7 gb   504 files short · 5.3 gb short
  newest here 16 feb · there 5 feb · 11 days behind
  6 predate the 6 feb sync · 412 after · imports preserve dates
»   + 2023/04-family     predates the last sync · 6 files · 35 mb · .jpg 6 · 26 apr 2023
      + DSC_00.JPG                                          5.8 mb  26 apr 2023
      …
    · 2023/04-family/cover.NEF        16 mb   11 jan  permissions   .f...p.....
  ▸ + 2024/02-hokkaido   412 files · 4.4 gb · .jpg 206 .nef 206 · 14 feb–16 feb · all created new
```

### What this adds

`%M` rides along with the fields `--out-format` already asks for, at no cost. Parsed in `itemize.ts`, stored as an optional `mtime`. The parser picks three-field vs four-field by the **shape** of the third field, so filenames containing `|` still work (rsync doesn't escape it) and a log written before this change replays as undated rather than as a parse failure.

With a date on every difference:

- **Pending files split across the last sync.** Written since it, they're a backlog; written before it and still absent, something skipped them. `lastSyncAt` reads `history.jsonl` rather than `state.json` — scans record when syncy last *looked*, and this needs when it last *copied*. Exit 24 counts, consistent with `checkUnit`.
- **Groups state what a set is** — how many, how big, of what, from when. One camera import is one line, not four hundred.
- **Groups rank by what is surprising**, not by kind. A pre-sync gap and a content difference outrank a bulk backlog. `ORDER` still governs the legend and the flat view.
- `[b]` cycles folder / type / age / flat; `[enter]` opens a group.

Two facts were already recorded and never read: both fingerprints carry `maxMtimeNs`, so *"the destination is 11 days behind"* needed no new capture at all.

### Three defects the rework exposed, fixed here

- A collapsed group reported **"0 differences."** The footer counted rows drawn — right while every difference was one row, a lie the moment one could be closed. It counts the record now.
- Suppressing the repeated itemize column **dropped the evidence entirely.** The group header states it once. Moving the column is a change of place; dropping it would be a change of claim.
- The cursor indexed **every** row including headers and prose, none of which draw a selection, so arrowing down from the top moved through five rows with nothing changing and the key appeared dead. It now steps between rows that can show they're selected, marked with the ledger's own `»`, drawn inside the existing indent so columns don't jitter.

### Review notes

- **Group ranking deliberately contradicts `ORDER`.** `test/diff.test.tsx` no longer asserts `new` sorts first; the test is rewritten with the reasoning.
- **The "predates the last sync" claim is hedged on purpose.** Camera imports and restores preserve mtimes, so an old date doesn't prove a file was there at sync time. Wording says which side of the line a file falls on and stops. There's a test that the caveat still fits a 76-column window with all clauses present — a hedge truncated off the end leaves the number reading as a certainty.
- `README.md` updates the three documented rsync commands; a test asserts they match `buildArgv`.
- New file: `test/difference-shape.test.tsx`, 50 tests.

789 tests pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)