### PR TITLE
Kill the transfer's whole process group on cancel

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -78,7 +78,15 @@ export function startSync(
   const writer = Bun.file(logPath).writer();
   writer.write(`# ${new Date(now).toISOString()}\n# ${[opts.bin ?? DEFAULT_RSYNC, ...argv].join(" ")}\n`);
 
-  const proc = Bun.spawn([opts.bin ?? DEFAULT_RSYNC, ...argv], { stdout: "pipe", stderr: "pipe" });
+  // Its own process group (POSIX setsid): a cancellation must reach everything
+  // the transfer forked, not just this process — and a terminal ctrl-c can no
+  // longer kill rsync under the app's feet. App's two-press handler is the
+  // single place a cancellation is decided.
+  const proc = Bun.spawn([opts.bin ?? DEFAULT_RSYNC, ...argv], {
+    stdout: "pipe",
+    stderr: "pipe",
+    detached: true,
+  });
   // Marks that separate rsync's own time from syncy's. "Slow to start" and
   // "slow to finish" have completely different causes — rsync enumerating a
   // network share, versus syncy doing work around it — and without these there
@@ -144,7 +152,17 @@ export function startSync(
     done,
     cancel(): void {
       cancelled = true;
-      proc.kill();
+      // The whole group, not just the leader. rsync's local copy runs its
+      // helper as a child of the process spawned here: a lone SIGTERM orphans
+      // the helper, which keeps the log pipes open (so `done` hangs until it
+      // notices on its own) and, mid-transfer, keeps writing to the target.
+      if (proc.exitCode === null) {
+        try {
+          process.kill(-proc.pid, "SIGTERM");
+        } catch {
+          proc.kill();
+        }
+      }
     },
   };
 }


### PR DESCRIPTION
Fixes #9.

`cancel()` was `proc.kill()` — a SIGTERM to the spawned process only. Its children survive: for a local rsync copy that is the receiving helper, which can keep writing to the destination after the job has reported `cancelled`, and in general it holds the log pipes open so `done` cannot resolve until it exits on its own.

The audit work's new confirm tests caught this in CI against a `sh -c sleep` stub: the shell died at once, but the job only reported `cancelled` once the orphaned `sleep` finished five seconds later (two red tests on both platforms).

**The change**

- `Bun.spawn(..., { detached: true })` — POSIX setsid; the transfer runs as its own process group, the child as leader.
- `cancel()` signals the group (`process.kill(-proc.pid, "SIGTERM")`), falling back to the direct child if the group is already gone, and only while the process has not exited.

The group-kill mechanism was verified outside Bun before writing this (setsid shell + orphaned sleep: lone shell TERM leaves the orphan holding the pipe; group TERM reaches it).

A side benefit: detached also removes rsync from the TUI's terminal foreground group, so a real-terminal ctrl-c can no longer kill rsync under the app's feet — the two-press logic in `App` becomes the single place a cancellation is decided.

**Verify**

- The two red tests (`esc while a transfer is running`) go green as-is; no test changes.
- Merge-tested against `chore/biome-lint` (PR #1): clean merge, `tsc --noEmit` and `biome check .` both clean on the combined tree.