### PR TITLE
Fix audit-history.sh on Linux: parse mounts by format, never word-split

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ own palette.
 ## Development
 
 ```
-bun test               # 816 tests
+bun test               # 834 tests
 bunx tsc --noEmit
 bunx @biomejs/biome@2.5.10 check .   # lint and format; --write to fix
 bun run build

--- a/scripts/audit-history.sh
+++ b/scripts/audit-history.sh
@@ -10,6 +10,11 @@
 # Patterns are derived from this machine rather than hardcoded, so the check
 # keeps working on someone else's and cannot be satisfied by scrubbing one
 # known string.
+#
+# The mount table comes from `mount`, or from $SYNCY_AUDIT_MOUNT_TABLE when
+# set (a test seam: a canned table, parsed the same way). The parsing is by
+# output format, not by OS, so the same canned tables exercise both the
+# macOS and the Linux shapes on any runner.
 
 set -eu
 cd "$(git rev-parse --show-toplevel)"
@@ -18,44 +23,69 @@ USERNAME=$(id -un)
 HOSTNAME_SHORT=$(hostname -s 2>/dev/null || echo "__no_such_host__")
 HOME_PATH=$(printf '%s' "$HOME" | sed 's/[.[\*^$]/\\&/g')
 
-# Mounted volume names, and the servers behind any network mounts.
-# Volume names can contain spaces, so capture up to the " (" that precedes the fstype.
-VOLUMES=$(mount 2>/dev/null | sed -n 's|.* on /Volumes/\([^(]*\) (.*|\1|p' | sed 's/ *$//' \
-  | grep -v '^\.' | sed 's/[.[\*^$]/\\&/g' | sort -u)
-# Server hostnames come from SMB (//host/share or //user@host/share) or NFS (host:/share) mounts.
-# Extract from the device field: remove leading //, strip any user@, then take up to the first / or :.
-# Only consider remote mounts: skip local device paths and pseudo-filesystems.
-SERVERS=$(mount 2>/dev/null | awk '$1 !~ /^\/dev\// && $1 !~ /^devfs$/ && $1 !~ /^map$/ && $1 !~ /^localhost/{
-  device=$1
-  host=device
-  gsub(/^\/\//, "", host)
-  gsub(/^[^@]*@/, "", host)
-  gsub(/[\/:].*/, "", host)
-  if (host != "") print host
-}' | sort -u)
+if [ -n "${SYNCY_AUDIT_MOUNT_TABLE:-}" ]; then
+  MOUNT_TABLE=$(cat "$SYNCY_AUDIT_MOUNT_TABLE" 2>/dev/null || true)
+else
+  MOUNT_TABLE=$(mount 2>/dev/null || true)
+fi
+
+# Volume names, as full mount-point paths: macOS /Volumes/<name> (BSD output
+# "… on /Volumes/<name> (fstype, …)") and Linux mount points under /media or
+# /mnt. The path is the identifier; a bare leaf name could be a common word.
+# Each sed extracts from the original table; the second must not filter the
+# first's output, or the first finds nothing in the second's stream.
+VOLUMES=$(
+  {
+    printf '%s\n' "$MOUNT_TABLE" | sed -n 's|.* on /Volumes/\([^(]*\) (.*|/Volumes/\1|p'
+    printf '%s\n' "$MOUNT_TABLE" | sed -n 's|.* on \(/\(media\|mnt\)/[^ (]*\) .*|\1|p'
+  } \
+  | sed 's/ *$//' \
+  | grep -v '/\.$' \
+  | sed 's/[.[\*^$]/\\&/g' \
+  | sort -u
+)
+
+# Network mount servers, recognized rather than local sources excluded.
+# CIFS: //host/share or //user@host/share. NFS: host:/share, host a name or
+# an address. (Excluding the known-local sources — the old way — let every
+# Linux pseudo-filesystem, proc, tmpfs, cgroup2, …, through as a "server".)
+SERVERS=$(printf '%s\n' "$MOUNT_TABLE" | awk '
+  {
+    device = $1
+    host = ""
+    if (device ~ /^\/\//) {
+      host = substr(device, 3)
+      sub(/^[^@]*@/, "", host)
+      sub(/[\/:].*/, "", host)
+    } else if (device !~ /^\// && index(device, ":") > 0) {
+      sub(/:.*/, "", device)
+      host = device
+    }
+    if (host ~ /^[A-Za-z0-9._-]+$/) print host
+  }' | sort -u)
 
 # The configured commit address. A generic address pattern matched
 # documentation instead: `//you@nas.local/share` is rsync's mount-source
 # syntax, not a person.
 GIT_EMAIL=$(git config user.email 2>/dev/null | sed 's/[.[\*^$]/\\&/g' || true)
 
-PATTERNS=$(
-  printf '%s\n' \
-    "$HOME_PATH" \
-    "(^|[^A-Za-z0-9])$USERNAME([^A-Za-z0-9]|\$)" \
-    "$HOSTNAME_SHORT" \
-    "([0-9]{1,3}\.){3}[0-9]{1,3}" \
-    "([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}"
-  [ -n "$GIT_EMAIL" ] && printf '%s\n' "$GIT_EMAIL"
-  # Preserve volume names containing spaces by splitting only on newlines.
-  IFS=$'\n'
-  for v in $VOLUMES; do printf '/Volumes/%s\n' "$v"; done
-  for s in $SERVERS; do printf '%s\n' "$s"; done
-)
-
+# One pattern per line, straight into the file. The lists above are already
+# newline-separated and may contain spaces, so they must never pass through
+# unquoted shell word-splitting: under dash, IFS=$'\n' is the literal
+# characters $, \, n, and splitting on n shatters every pattern that contains
+# one into one- and two-letter fragments that match nearly every line.
 PATFILE=$(mktemp)
 trap 'rm -f "$PATFILE"' EXIT
-printf '%s\n' "$PATTERNS" | grep -v '^$' > "$PATFILE"
+{
+  printf '%s\n' "$HOME_PATH"
+  printf '(^|[^A-Za-z0-9])%s([^A-Za-z0-9]|$)\n' "$USERNAME"
+  printf '%s\n' "$HOSTNAME_SHORT"
+  printf '([0-9]{1,3}\.){3}[0-9]{1,3}\n'
+  printf '([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}\n'
+  [ -n "$GIT_EMAIL" ] && printf '%s\n' "$GIT_EMAIL"
+  printf '%s\n' "$VOLUMES"
+  printf '%s\n' "$SERVERS"
+} | grep -v '^$' > "$PATFILE"
 
 fail=0
 

--- a/scripts/audit-history.sh
+++ b/scripts/audit-history.sh
@@ -34,13 +34,20 @@ fi
 # /mnt. The path is the identifier; a bare leaf name could be a common word.
 # Each sed extracts from the original table; the second must not filter the
 # first's output, or the first finds nothing in the second's stream.
+#
+# The Linux extraction is an ERE (`sed -E`) because alternation is what it
+# needs and `\|` is a GNU extension: under BSD sed it is a literal pipe, so
+# the BRE form silently matched nothing and every /media and /mnt volume went
+# underived on the machine this script is usually run from. The delimiter is
+# `#` for the same reason — `|` cannot delimit a substitution that contains
+# alternation.
 VOLUMES=$(
   {
     printf '%s\n' "$MOUNT_TABLE" | sed -n 's|.* on /Volumes/\([^(]*\) (.*|/Volumes/\1|p'
-    printf '%s\n' "$MOUNT_TABLE" | sed -n 's|.* on \(/\(media\|mnt\)/[^ (]*\) .*|\1|p'
+    printf '%s\n' "$MOUNT_TABLE" | sed -n -E 's#.* on (/(media|mnt)/[^ (]*) .*#\1#p'
   } \
   | sed 's/ *$//' \
-  | grep -v '/\.$' \
+  | grep -v '/\.' \
   | sed 's/[.[\*^$]/\\&/g' \
   | sort -u
 )

--- a/test/audit-script.test.ts
+++ b/test/audit-script.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { makeFixtureDir, removeFixtureDir } from "./helpers.ts";
+
+/**
+ * The audit script is a guard, so the tests plant the leaks: a guard that
+ * passes over a planted identifier has failed for the reason it exists. The
+ * mount table is fed through SYNCY_AUDIT_MOUNT_TABLE, canned and format-based
+ * (BSD and Linux shapes both, on any runner), so what is exercised is the
+ * derivation and the scans, not this machine's mounts.
+ *
+ * The script is spawned through its #!/bin/sh shebang: on Linux that is dash,
+ * where the old IFS=$'\n' was the literal characters $, \, n — the tests
+ * would have caught that regression on the platform it breaks.
+ */
+
+const SCRIPT = join(import.meta.dir, "..", "scripts", "audit-history.sh");
+
+const LINUX_TABLE =
+  [
+    "/dev/nvme0n1p2 on / type ext4 (rw,relatime,errors=remount-ro)",
+    "proc on /proc type proc (rw,nosuid,nodev)",
+    "sysfs on /sys type sysfs (rw,nosuid,nodev)",
+    "tmpfs on /run type tmpfs (rw,nosuid)",
+    "cgroup2 on /sys/fs/cgroup type cgroup2 (rw,nosuid)",
+    "devpts on /dev/pts type devpts (rw,nosuid)",
+    "/dev/sdb1 on /media/user/Archive type vfat (rw,uid=1000)",
+  ].join("\n") + "\n";
+
+const LINUX_TABLE_CIFS =
+  LINUX_TABLE + "//auditnas/share on /mnt/backup type cifs (rw,vers=3.11,uid=1000)\n";
+
+const BSD_TABLE =
+  [
+    "/dev/disk3s3s1 on / (apfs, local, journaled, owner=root)",
+    "devfs on /dev (devfs, local, nobrowse, multi-label)",
+    "map auto_home on /System/Volumes/Data/home (autofs, nomount, map=auto_home)",
+    "//backupbox/media on /Volumes/backup (smb, noatime, mount from backupbox)",
+    "/dev/disk4s1 on /Volumes/Archive (hfs, local, journaled)",
+  ].join("\n") + "\n";
+
+const repos: string[] = [];
+afterEach(() => {
+  for (const r of repos.splice(0)) removeFixtureDir(r);
+});
+
+const git = (repo: string, ...args: string[]): string =>
+  Bun.spawnSync(["git", "-C", repo, ...args], {
+    env: { ...process.env },
+    stdout: "pipe",
+    stderr: "pipe",
+  }).stdout.toString();
+
+function plantRepo(files: Record<string, string>, message: string): string {
+  const repo = makeFixtureDir("syncy-audit");
+  repos.push(repo);
+  git(repo, "init", "-q");
+  git(repo, "config", "user.name", "Fixture");
+  git(repo, "config", "user.email", "fixture@example.com");
+  for (const [name, body] of Object.entries(files)) writeFileSync(join(repo, name), body);
+  git(repo, "add", "-A");
+  git(repo, "commit", "-q", "-m", message);
+  return repo;
+}
+
+function runAudit(repo: string, table: string): Promise<{ code: number; out: string }> {
+  const tablePath = join(repo, ".audit-mount-table");
+  writeFileSync(tablePath, table);
+  const proc = Bun.spawn(["sh", SCRIPT], {
+    cwd: repo,
+    env: { ...process.env, SYNCY_AUDIT_MOUNT_TABLE: tablePath },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  let out = "";
+  const pump = async (s: ReadableStream<Uint8Array>): Promise<void> => {
+    const decoder = new TextDecoder();
+    for await (const chunk of s) out += decoder.decode(chunk, { stream: true });
+  };
+  return Promise.all([proc.exited, pump(proc.stdout), pump(proc.stderr)]).then(([code]) => ({
+    code: code as number,
+    out,
+  }));
+}
+
+const leaks = (out: string): string[] => out.split("\n").filter((l) => l.includes("LEAK"));
+
+describe("audit-history.sh", () => {
+  test("a clean repo passes, with pseudo-filesystem words in the tree", async () => {
+    // proc, tmpfs and cgroup2 are Linux mount sources, not servers. As
+    // patterns they would match "process" and friends all over any repo, so
+    // the decoy file is the regression test for the old exclusion list.
+    const repo = plantRepo(
+      { "notes.txt": "the process runs on tmpfs under cgroup2 with a proc entry\n" },
+      "notes",
+    );
+    const r = await runAudit(repo, LINUX_TABLE);
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("OK");
+    expect(leaks(r.out)).toHaveLength(0);
+  });
+
+  test("a planted network server is caught, and only that", async () => {
+    const repo = plantRepo(
+      {
+        "notes.txt": "backups land on //auditnas/share\n",
+        "decoys.txt": "the process runs on tmpfs under cgroup2\n",
+      },
+      "notes",
+    );
+    const r = await runAudit(repo, LINUX_TABLE_CIFS);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("FAIL");
+    // One tree hit and one blob hit, both the planted file. A shattering IFS
+    // or a pseudo-filesystem "server" would add hits for the decoys.
+    const l = leaks(r.out);
+    expect(l).toHaveLength(2);
+    for (const line of l) expect(line).toContain("notes");
+    // The commit message was clean, and said so.
+    expect(r.out).toContain("== commit messages ==\n  clean");
+  });
+
+  test("the macOS table shape yields its volumes and its server", async () => {
+    const repo = plantRepo(
+      {
+        "volume-note.txt": "the archive is on /Volumes/Archive\n",
+        "server-note.txt": "backups are on //backupbox/media\n",
+      },
+      "notes",
+    );
+    const r = await runAudit(repo, BSD_TABLE);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("FAIL");
+    const l = leaks(r.out);
+    // Two tree hits (one per pattern, different files) and two blob hits.
+    expect(l).toHaveLength(4);
+    expect(l.some((line) => line.includes("volume-note"))).toBe(true);
+    expect(l.some((line) => line.includes("server-note"))).toBe(true);
+    for (const line of l) expect(line).toContain("note");
+  });
+
+  test("a leak in commit history is caught, not just in the tree", async () => {
+    // The incident that made this script: a hostname committed once survives
+    // every later cleanup of the tip. The message is the leak, the tree is
+    // clean.
+    const repo = plantRepo(
+      { "notes.txt": "clean content\n" },
+      "moved //auditnas/share to the new box",
+    );
+    const r = await runAudit(repo, LINUX_TABLE_CIFS);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("FAIL");
+    expect(r.out).toContain("moved //auditnas/share to the new box");
+    // Only the message: the tree and the blobs are clean.
+    expect(r.out).toContain("== working tree ==\n  clean");
+    const l = leaks(r.out);
+    expect(l).toHaveLength(1);
+    expect(l[0]).toContain("auditnas");
+  });
+});

--- a/test/audit-script.test.ts
+++ b/test/audit-script.test.ts
@@ -10,9 +10,11 @@ import { makeFixtureDir, removeFixtureDir } from "./helpers.ts";
  * (BSD and Linux shapes both, on any runner), so what is exercised is the
  * derivation and the scans, not this machine's mounts.
  *
- * The script is spawned through its #!/bin/sh shebang: on Linux that is dash,
- * where the old IFS=$'\n' was the literal characters $, \, n — the tests
- * would have caught that regression on the platform it breaks.
+ * The script is spawned under `sh` explicitly, which is what its own shebang
+ * asks for: on Linux that is dash, where the old IFS=$'\n' was the literal
+ * characters $, \, n — the tests would have caught that regression on the
+ * platform it breaks. On macOS it is bash in sh-compat mode, which is what
+ * catches the reverse: a GNU-only construct that never runs here.
  */
 
 const SCRIPT = join(import.meta.dir, "..", "scripts", "audit-history.sh");
@@ -99,6 +101,37 @@ describe("audit-history.sh", () => {
     expect(r.code).toBe(0);
     expect(r.out).toContain("OK");
     expect(leaks(r.out)).toHaveLength(0);
+  });
+
+  test("a Linux volume under /media is derived, not just macOS /Volumes", async () => {
+    // The extraction that was written as a BRE with `\|`, which is a GNU
+    // extension: under BSD sed it matched nothing and this leak walked
+    // straight past the guard on the author's own machine. Planting the path
+    // is the only way the alternation gets exercised on either sed.
+    const repo = plantRepo({ "notes.txt": "the archive lives at /media/user/Archive\n" }, "notes");
+    const r = await runAudit(repo, LINUX_TABLE);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("FAIL");
+    expect(leaks(r.out).length).toBeGreaterThan(0);
+  });
+
+  test("a hidden mount point contributes no pattern", async () => {
+    // Time Machine mounts at /Volumes/.timemachine/<host>/<uuid>/Data, which
+    // is noise, not a volume anyone syncs to. The leading-dot exclusion used
+    // to run against the bare leaf name; once the paths became whole it was
+    // written `/\.$`, which only ever matches a line *ending* in "/." — so
+    // it excluded nothing. The mount point is the bait: if it is still a
+    // pattern, this clean repo fails.
+    const repo = plantRepo(
+      { "notes.txt": "snapshots live under /Volumes/.timemachine/box/1-A/Data\n" },
+      "notes",
+    );
+    const r = await runAudit(
+      repo,
+      `${BSD_TABLE}//tm@timecapsule/backups on /Volumes/.timemachine/box/1-A/Data (smb, nobrowse)\n`,
+    );
+    expect(r.out).toContain("OK");
+    expect(r.code).toBe(0);
   });
 
   test("a planted network server is caught, and only that", async () => {


### PR DESCRIPTION
Fixes #10. Stacked on the CI PR so the new tests get a runner; rebase to `main` (or change the base) once #5 lands.

On Linux `bun run audit` flagged nearly every reachable blob. Three defects in the pattern derivation; the scans themselves were portable.

**1. `IFS=$'\n'` under dash.** The shebang is `#!/bin/sh`: on macOS that is bash in sh-compat mode, which understands `$'\n'`; on Linux it is dash, where it is the literal characters `$`, `\`, `n`. IFS then contains the letter n, and the unquoted for-loop splits every pattern at each n — `binfmt_misc` becomes `bi` and `fmt_misc` — so one- and two-letter patterns match nearly every line. The lists now go straight into the pattern file, one per line; the for-loops are gone, and volume names with spaces no longer need saving.

**2. SERVERS excluded known-local sources, which inverts on Linux.** macOS mount sources are local devices, `devfs`, `map`, or network mounts, so the exclusion isolated the servers. Linux sources also include `proc`, `sysfs`, `tmpfs`, `cgroup2`, …, none of which are excluded, so every pseudo-filesystem became a "server" and `proc` matched `process` all over the tree. Now a source is a server iff it is one (recognized, not excluded): `//host/share` or `//user@host/share` (CIFS), `host:/share` (NFS). Same result on macOS for real network mounts, and `local` is no longer a pattern there either.

**3. VOLUMES was macOS-only by construction** (the `/Volumes/` sed), so Linux derived nothing. Mount points under `/media` and `/mnt` are now added as whole paths — the path is the identifier, the leaf could be a common word. Both extractions read the original table; a second sed filtering the first's output finds nothing in it. (This one was caught by the test below, not by the manual run — the manual run's mounts had no `/Volumes` or `/media` entries to expose it.)

The mount table can come from `$SYNCY_AUDIT_MOUNT_TABLE` (a test seam). `test/audit-script.test.ts` spawns the script through its shebang (dash on Linux, where defect 1 lived) against fixture repos with canned BSD and Linux tables:

- a clean repo with pseudo-filesystem decoys passes,
- a planted CIFS server is caught — and only that (two leak lines, both the planted file),
- the BSD shape yields its volumes and its server,
- a leak in a commit message is caught while the tree is clean.

Verified by running the script here against the real repo: all three sections clean, exit 0 — the first time it has actually run on this machine. `shellcheck` is not installed on this machine; the script passes `sh -n` and the suite.