### PR TITLE
Make the confirm page readable before you let it write

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -402,12 +402,21 @@ the render loop never blocks on rsync, and log lines commit in batches at
 ~20 fps rather than per line.
 
 **Sync guard rails.** `s` opens a full-page confirm — not a floating modal —
-showing the literal argv, the pending change count, and five checks as a
-readable list: `rsync`, `source`, `sentinel`, `space`, `dry run`. It refuses to
+showing the literal argv, the pending change count split into what the transfer
+creates and what it overwrites, and five checks as a readable list: `rsync`, `source`, `sentinel`, `space`, `dry run`. It refuses to
 launch when the sentinel is missing or mismatched, when free space is under
 `bytes_pending * 1.05`, or when `--delete` appears without `-n`. The `dry run`
 row reads `no · this writes to the target` on a real sync — stated, never
 implied.
+
+Creations and replacements are separated because they carry different weight: a
+file that is not at the destination is a backlog, while one that is already
+there and differs has bytes about to be overwritten. That split also decides
+repair mode — the `-c` sync — which is set from what a deep verify *found*, not
+from the method alone. A deep verify whose every difference is a creation needs
+no `-c`: rsync copies a file that is not there whatever it compares by, so the
+flag only bought hours of re-reading the source under a heading claiming those
+files differ by content.
 
 The argv is appended to `history.jsonl` with `exitCode: null` **before** the
 process spawns, and again with the real exit code when it finishes, so a sync

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -409,6 +409,16 @@ launch when the sentinel is missing or mismatched, when free space is under
 row reads `no · this writes to the target` on a real sync — stated, never
 implied.
 
+A folder can be behind on more than one destination, and `s` names only one of
+them. The confirm page lists the others with what each is behind by, and `tab`
+moves between them — the counts, the checks and the argv all re-derive. The
+choice lives here rather than in the ledger, which selects folders: a folder is
+the unit of work for every other key, and `s` is the only one that needs a
+single destination. Before this the second destination could not be synced at
+all until the first was clean. A preflight is stamped with the destination it
+ran against, because `ok` gates the launch and a result carried across a switch
+would clear a sync that nothing had checked.
+
 Creations and replacements are separated because they carry different weight: a
 file that is not at the destination is a backlog, while one that is already
 there and differs has bytes about to be overwritten. That split also decides

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ Keys: `enter` differences, `q` quick check, `d` deep verify, `s` sync,
 `p` commands, `e` evidence, `f` filter, `,` setup, `?` all keys, `ctrl-c` quit
 (during a transfer the first press cancels it; a second quits).
 Hold shift to run a check against every folder rather than the selected one.
+`s` offers the first destination the folder is behind on; `tab` on the confirm
+page moves between the others, re-deriving the counts, the checks and the
+command for each.
 
 syncy sets the terminal window and tab title, so a check running in a background
 window can be read from the tab strip: `50% deep 19-01-01 - 2019 · syncy` while

--- a/src/rsync.ts
+++ b/src/rsync.ts
@@ -129,6 +129,90 @@ export function buildArgv(
   return argv;
 }
 
+export interface FlagGloss {
+  readonly flag: string;
+  /** What this flag does, in the terms the screen's reader needs. */
+  readonly gloss: string;
+}
+
+/**
+ * The argv in words, for the screens that show it (DESIGN.md section 6).
+ *
+ * The confirm page's promise is that nothing runs that is not shown first —
+ * which only holds if the thing shown can be read. `-a -A -X -i
+ * --out-format=%i|%l|%M|%n` is exact and inert: it satisfies the letter of
+ * "shown" while telling someone deciding whether to write to a drive nothing
+ * they can decide on.
+ *
+ * Glossed here rather than in the components, beside the `buildArgv` that
+ * emits them, so a flag and its explanation are added in one place. The test
+ * suite walks every mode and option `argvFor` can produce and fails on any
+ * flag this does not cover — the only thing that actually keeps the two from
+ * drifting.
+ *
+ * The two path arguments are dropped: the screens already show them, on their
+ * own lines, where a long path can be truncated from the middle.
+ */
+export function glossArgv(argv: readonly string[]): FlagGloss[] {
+  const flags = argv.slice(0, -2);
+  // `--delete` means something different depending on company it keeps, and
+  // this is read by someone deciding whether to let it run. Never describe it
+  // as listing-only without checking that -n is actually there.
+  const dryRun = flags.some(
+    (a) => a === "-n" || a === "--dry-run" || (/^-[a-zA-Z]+$/.test(a) && a.includes("n")),
+  );
+  const out: FlagGloss[] = [];
+  for (const flag of flags) {
+    const gloss = glossFlag(flag, dryRun);
+    if (gloss !== null) out.push({ flag, gloss });
+  }
+  return out;
+}
+
+/** Returns null for a flag with no gloss, which the screens show bare. */
+export function glossFlag(flag: string, dryRun: boolean): string | null {
+  switch (flag) {
+    case "-a":
+      return "recurse; keep times, permissions, symlinks, owner and group";
+    case "-A":
+      return "keep ACLs too";
+    case "-X":
+      return "keep extended attributes — Finder tags, quarantine";
+    case "--no-perms":
+      return "do not keep permissions — this destination cannot store them";
+    case "-c":
+      return "compare contents, not size and date — slow, catches bit rot";
+    case "-n":
+      return "dry run — reports what it would do, writes nothing";
+    case "-i":
+      return "one line per file it acts on";
+    case "-vv":
+      return "a line for files it leaves alone too — the only progress there is";
+    case "--delete":
+      return dryRun
+        ? "also list destination-only files — under -n, deletes nothing"
+        : "DELETES files at the destination that are not at the source";
+  }
+  if (flag.startsWith("--out-format=")) {
+    return "each line: change flags, size, source mtime, name";
+  }
+  if (flag.startsWith("--partial-dir=")) {
+    const dir = flag.slice("--partial-dir=".length);
+    return `an interrupted file parks under ${dir}, not at its final name`;
+  }
+  if (flag.startsWith("--modify-window=")) {
+    const n = flag.slice("--modify-window=".length);
+    return `timestamps within ${n}s count as equal — this filesystem's granularity`;
+  }
+  if (flag.startsWith("--exclude=")) {
+    const pat = flag.slice("--exclude=".length);
+    return pat.startsWith(".syncy-")
+      ? "skip syncy's own scratch files, a parked partial among them"
+      : `skip anything matching ${pat}`;
+  }
+  return null;
+}
+
 /**
  * Builds the argv for one unit at one destination — the single place every
  * caller turns a (config, unit, target) triple into a real rsync invocation.

--- a/src/status.ts
+++ b/src/status.ts
@@ -41,14 +41,30 @@ export interface Cell {
   readonly state: CellState;
   readonly reason: string;
   readonly nChanges: number;
+  /**
+   * Of `nChanges`, the ones that are not at the destination at all.
+   *
+   * Absent on records written before it was tracked, which the views report as
+   * no breakdown rather than as a guess. `nChanges - nNew` is what a sync
+   * overwrites, and the two carry very different weight: one is a backlog, the
+   * other replaces bytes that are already there.
+   */
+  readonly nNew?: number;
   readonly bytesPending: number;
   readonly nExtra: number;
   /**
-   * The drift was found by a deep verify, so a plain sync will not fix it.
+   * A deep verify found files whose content differs, so a plain sync will not
+   * fix them.
    *
    * Bit rot leaves size and mtime intact, so rsync's default quick check skips
    * exactly the file that needs replacing. Syncing such a folder without `-c`
    * reports success and changes nothing.
+   *
+   * Set from what the check *found*, not from the method alone. A deep verify
+   * whose 504 differences are all creations needs no `-c`: rsync copies a file
+   * that is not there whatever it compares by, so the flag only bought hours
+   * of re-reading the source, under a heading that said those files differ by
+   * content when none of them did.
    */
   readonly needsChecksum?: boolean;
 }
@@ -222,11 +238,16 @@ export function cellState(input: CellInput): Cell {
       state: "missing",
       reason: "never copied",
       nChanges: input.fingerprintNow.nfiles,
+      // Nothing is at the destination, so every file is a creation.
+      nNew: input.fingerprintNow.nfiles,
       bytesPending: input.fingerprintNow.bytes,
     };
   }
   if (latest.outcome === "behind") {
-    const byChecksum = latest.method === "deep";
+    // Records predating `nNew` carry no breakdown, so they keep the older,
+    // conservative reading: method alone.
+    const byChecksum =
+      latest.method === "deep" && (latest.nNew === undefined || latest.nNew < latest.nChanges);
     return {
       ...extra,
       state: "behind",
@@ -237,6 +258,7 @@ export function cellState(input: CellInput): Cell {
       // this does too.
       reason: behindReason(latest),
       nChanges: latest.nChanges,
+      ...(latest.nNew !== undefined ? { nNew: latest.nNew } : {}),
       bytesPending: latest.bytesPending,
       ...(byChecksum ? { needsChecksum: true } : {}),
     };

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -340,6 +340,7 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
         unit={pendingSync.unit}
         target={syncTarget}
         nChanges={syncCell?.nChanges ?? 0}
+        {...(syncCell?.nNew === undefined ? {} : { nNew: syncCell.nNew })}
         nExtra={syncCell?.nExtra ?? 0}
         bytesPending={syncCell?.bytesPending ?? 0}
         {...(syncCell?.needsChecksum === true ? { needsChecksum: true } : {})}

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -304,8 +304,12 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
           if (rows[clampedSelection] !== undefined) setShowPlan(true);
         },
         startSync: () => {
-          // Offer the target that is furthest behind; there is nothing to sync
-          // to a target that is already clean.
+          // Offer the first destination that is behind — there is nothing to
+          // sync to one that is already clean — and let the confirm page's
+          // [tab] reach the others. The comment here used to claim "furthest
+          // behind", which `find` has never done; with the switcher the order
+          // is a starting point rather than a verdict, so first-in-ledger-order
+          // is both what happens and what it should be.
           // A sync writes; starting one while a check is reading the same tree
           // would have the two disagree about what is there.
           if (running !== null) {
@@ -333,10 +337,27 @@ export function App({ config: initialConfig, bin }: AppProps): React.ReactElemen
     syncing === null ? undefined : config.targets.find((t) => t.name === syncing.target);
   const syncCell = syncRow?.status.cells.find((c) => c.target === syncing?.target);
 
+  // Every destination this folder is behind on, in ledger order. `s` offers
+  // the first and `[tab]` on the confirm page reaches the rest; before this,
+  // a second behind destination could not be synced at all until the first
+  // was clean.
+  const syncCandidates =
+    syncRow === undefined
+      ? []
+      : syncRow.status.cells
+          .filter((c) => c.state === "behind" || c.state === "missing")
+          .map((c) => ({
+            name: c.target,
+            nChanges: c.nChanges,
+            bytesPending: c.bytesPending,
+          }));
+
   if (pendingSync !== null && syncRow !== undefined && syncTarget !== undefined) {
     return (
       <Confirm
         config={config}
+        candidates={syncCandidates}
+        onSwitch={(name) => setPendingSync({ unit: pendingSync.unit, target: name })}
         unit={pendingSync.unit}
         target={syncTarget}
         nChanges={syncCell?.nChanges ?? 0}
@@ -553,6 +574,7 @@ export function Help({
       {line("q / Q", "quick check — this folder / all · size and date · writes nothing")}
       {line("d / D", "deep verify — this folder / all · checksums · writes nothing")}
       {line("s", "sync — copies what is missing · the only key that writes")}
+      {line("  tab", "on the confirm page: switch which destination to sync to")}
       {line("p", "show the exact rsync command each of those runs")}
       {line("enter", "which files differ, per destination")}
       {line("e", "evidence for the selected folder")}

--- a/src/tui/Confirm.tsx
+++ b/src/tui/Confirm.tsx
@@ -22,6 +22,8 @@ export interface ConfirmProps {
   readonly unit: string;
   readonly target: Target;
   readonly nChanges: number;
+  /** Of `nChanges`, the ones not at the destination at all. */
+  readonly nNew?: number;
   readonly nExtra: number;
   readonly bytesPending: number;
   /** Repair mode: the drift was found by checksum, so the sync needs -c. */
@@ -31,6 +33,26 @@ export interface ConfirmProps {
   readonly height?: number;
   readonly onRun: () => void;
   readonly onCancel: () => void;
+}
+
+/**
+ * New versus replaced, which "504 files" on its own cannot say.
+ *
+ * A creation adds to the destination; a replacement overwrites bytes that are
+ * already there. Only the second is worth pausing over, and the page was
+ * asking for a decision without separating them — under a repair-mode heading
+ * that says "the only way to replace them" above a transfer that replaces
+ * nothing.
+ *
+ * Returns null for checks written before `nNew` was tracked: no breakdown is
+ * better than an invented one, the same rule `behindReason` follows.
+ */
+export function replaceLine(nChanges: number, nNew: number | undefined): string | null {
+  if (nNew === undefined) return null;
+  const nOld = nChanges - nNew;
+  if (nOld <= 0) return `nothing — all ${count(nChanges)} are new at the destination`;
+  if (nNew <= 0) return `all ${count(nChanges)} — every one is already there and differs`;
+  return `${count(nOld)} of them · the other ${count(nNew)} are new at the destination`;
 }
 
 export function Confirm(props: ConfirmProps): React.ReactElement {
@@ -115,10 +137,16 @@ export function Confirm(props: ConfirmProps): React.ReactElement {
       <Rule width={W} theme={theme} />
 
       {row("will transfer", `${count(props.nChanges)} files · ${bytes(props.bytesPending)}`)}
+      {(() => {
+        const line = replaceLine(props.nChanges, props.nNew);
+        return line === null ? null : row("will replace", line);
+      })()}
       {props.needsChecksum === true
         ? row(
             "repair mode",
-            "these differ by content, so this compares by checksum — slower, and the only way to replace them",
+            // The count only when the check recorded one; older records keep
+            // the bare wording rather than reporting every change as content.
+            `${props.nNew === undefined ? "these" : count(props.nChanges - props.nNew)} differ by content, so this compares by checksum — slower, and the only way to replace them`,
             theme.unverified,
           )
         : null}

--- a/src/tui/Confirm.tsx
+++ b/src/tui/Confirm.tsx
@@ -232,7 +232,12 @@ export function Confirm(props: ConfirmProps): React.ReactElement {
           // Named, with their own figures, rather than a bare "2 others": the
           // point of showing them is to make the choice between them, and
           // "NAS · 143 files" is what that choice is made on.
-          <Text color={theme.dim}>{truncate(`   also behind: ${others}`, Math.max(10, W - unit.length - target.name.length - 12))}</Text>
+          <Text color={theme.dim}>
+            {truncate(
+              `   also behind: ${others}`,
+              Math.max(10, W - unit.length - target.name.length - 12),
+            )}
+          </Text>
         )}
       </Box>
       <Rule width={W} theme={theme} />

--- a/src/tui/Confirm.tsx
+++ b/src/tui/Confirm.tsx
@@ -17,10 +17,30 @@ import type { Theme } from "./theme.ts";
  * phrased as "are you sure?"; it states what will happen.
  */
 
+/** One destination this folder could be synced to, for the switcher. */
+export interface SyncCandidate {
+  readonly name: string;
+  readonly nChanges: number;
+  readonly bytesPending: number;
+}
+
 export interface ConfirmProps {
   readonly config: Config;
   readonly unit: string;
   readonly target: Target;
+  /**
+   * Every destination this folder is behind on, in ledger order, including
+   * `target`. `[tab]` moves between them.
+   *
+   * `s` picked the first behind-or-missing destination and offered no way to
+   * reach the others: with two behind, the second was unreachable until the
+   * first was clean. The choice belongs here rather than in the ledger, which
+   * selects folders — a folder is the unit of work for every other key, and
+   * `s` is the only one that needs a single destination.
+   */
+  readonly candidates?: readonly SyncCandidate[];
+  /** Called with the name of the destination to switch to. */
+  readonly onSwitch?: (name: string) => void;
   readonly nChanges: number;
   /** Of `nChanges`, the ones not at the destination at all. */
   readonly nNew?: number;
@@ -55,9 +75,29 @@ export function replaceLine(nChanges: number, nNew: number | undefined): string 
   return `${count(nOld)} of them · the other ${count(nNew)} are new at the destination`;
 }
 
+/** The next destination in the cycle, or null when there is nowhere to go. */
+export function nextCandidate(
+  candidates: readonly SyncCandidate[] | undefined,
+  current: string,
+): string | null {
+  if (candidates === undefined || candidates.length < 2) return null;
+  const at = candidates.findIndex((c) => c.name === current);
+  // A current destination that is not in the list means the caller and this
+  // page disagree about what is on offer; cycling from position 0 is a guess.
+  if (at < 0) return null;
+  return candidates[(at + 1) % candidates.length]!.name;
+}
+
 export function Confirm(props: ConfirmProps): React.ReactElement {
   const { config, unit, target, theme, width, height, onRun, onCancel } = props;
-  const [pre, setPre] = useState<Preflight | null>(null);
+  // The preflight is stamped with the destination it ran against. `[tab]`
+  // changes the destination while the page is up, and a result carried over
+  // from the previous one would put its checks under the new one's heading —
+  // and, since `ok` gates the launch, would let enter run a sync nothing had
+  // actually checked. Anything not stamped with the current destination reads
+  // as "still running", which is what it is.
+  const [pre, setPre] = useState<{ target: string; result: Preflight } | null>(null);
+  const ready = pre !== null && pre.target === target.name ? pre.result : null;
 
   // The same argvFor the executor (startSync) calls — not a second construction
   // of the same paths that merely happens to agree with it. This is what
@@ -66,36 +106,47 @@ export function Confirm(props: ConfirmProps): React.ReactElement {
     ...(props.needsChecksum === true ? { checksum: true } : {}),
   });
 
-  // `argv` is deliberately not a dependency: it is the same argvFor call the
-  // executor makes, frozen for the lifetime of this page — the confirm screen
-  // owns the keyboard while it is up, so nothing that could change the argv
-  // can change the props either. Listing it (a fresh array every render)
-  // would re-run preflight — spawning rsync — on every parent render.
+  // `argv` is deliberately not a dependency: listing it (a fresh array every
+  // render) would re-run preflight — spawning rsync — on every parent render.
+  // Everything argvFor reads is a dependency instead: `config`, `target`, and
+  // `needsChecksum`, which travels with the destination. `[tab]` changes the
+  // destination, so this is no longer frozen for the page's lifetime, and the
+  // stamped result above is what keeps a stale preflight from being read as
+  // the current one's.
   // biome-ignore lint/correctness/useExhaustiveDependencies: see above.
   useEffect(() => {
     let live = true;
+    const ranAgainst = target.name;
     preflight(config, target, argv, props.bytesPending)
       .then((p) => {
-        if (live) setPre(p);
+        if (live) setPre({ target: ranAgainst, result: p });
       })
       .catch((e: unknown) => {
         // A preflight that fails to run is a blocked launch, never an allowed one.
         if (live) {
           setPre({
-            ok: false,
-            freeAfter: null,
-            checks: [{ name: "rsync", ok: false, detail: `preflight failed: ${String(e)}` }],
+            target: ranAgainst,
+            result: {
+              ok: false,
+              freeAfter: null,
+              checks: [{ name: "rsync", ok: false, detail: `preflight failed: ${String(e)}` }],
+            },
           });
         }
       });
     return () => {
       live = false;
     };
-  }, [config, target, props.bytesPending]);
+  }, [config, target, props.bytesPending, props.needsChecksum]);
+
+  const nextTarget = nextCandidate(props.candidates, target.name);
 
   useInput((input, key) => {
     if (key.escape || input === "q") return onCancel();
-    if (key.return && pre?.ok === true) return onRun();
+    if (key.tab && nextTarget !== null && props.onSwitch !== undefined) {
+      return props.onSwitch(nextTarget);
+    }
+    if (key.return && ready?.ok === true) return onRun();
   });
 
   const W = width;
@@ -122,6 +173,13 @@ export function Confirm(props: ConfirmProps): React.ReactElement {
   const legend = height === undefined || height - RESERVED_ROWS >= gloss.length ? gloss : [];
   const flagColumn = Math.min(28, Math.max(0, ...legend.map((g) => g.flag.length)));
 
+  // Every other destination this folder is behind on, with the figures the
+  // choice is actually made on.
+  const others = (props.candidates ?? [])
+    .filter((c) => c.name !== target.name)
+    .map((c) => `${c.name} ${count(c.nChanges)} files · ${bytes(c.bytesPending)}`)
+    .join("   ");
+
   const footer = (
     <Box flexDirection="column">
       {/* The literal argv. Nothing runs that is not shown here first. */}
@@ -142,10 +200,18 @@ export function Confirm(props: ConfirmProps): React.ReactElement {
         </Box>
       )}
       <Text> </Text>
-      {pre !== null && !pre.ok ? (
-        <Text color={theme.missing}>{"  blocked — a check failed. [esc] back"}</Text>
+      {ready !== null && !ready.ok ? (
+        <Text color={theme.missing}>
+          {nextTarget === null
+            ? "  blocked — a check failed. [esc] back"
+            : `  blocked — a check failed. [tab] try ${nextTarget}   [esc] back`}
+        </Text>
       ) : (
-        <Text color={theme.dim}>{"  [enter] run   [esc] cancel"}</Text>
+        <Text color={theme.dim}>
+          {nextTarget === null
+            ? "  [enter] run   [esc] cancel"
+            : `  [enter] run   [tab] switch to ${nextTarget}   [esc] cancel`}
+        </Text>
       )}
     </Box>
   );
@@ -162,6 +228,12 @@ export function Confirm(props: ConfirmProps): React.ReactElement {
         <Text color={theme.figure}>{"  " + unit}</Text>
         <Text color={theme.dim}>{"  →  "}</Text>
         <Text color={theme.figure}>{target.name}</Text>
+        {others.length === 0 ? null : (
+          // Named, with their own figures, rather than a bare "2 others": the
+          // point of showing them is to make the choice between them, and
+          // "NAS · 143 files" is what that choice is made on.
+          <Text color={theme.dim}>{truncate(`   also behind: ${others}`, Math.max(10, W - unit.length - target.name.length - 12))}</Text>
+        )}
       </Box>
       <Rule width={W} theme={theme} />
 
@@ -186,13 +258,13 @@ export function Confirm(props: ConfirmProps): React.ReactElement {
           : "nothing — this command carries no --delete",
       )}
       {row("destination", truncatePath(join(target.path, unit), 50))}
-      {pre?.freeAfter != null ? row("free after", bytes(pre.freeAfter)) : null}
+      {ready?.freeAfter != null ? row("free after", bytes(ready.freeAfter)) : null}
       <Text> </Text>
 
-      {pre === null ? (
+      {ready === null ? (
         <Text color={theme.dim}>{"  checks                running…"}</Text>
       ) : (
-        pre.checks.map((c, i) => (
+        ready.checks.map((c, i) => (
           <Box key={c.name}>
             <Text color={theme.dim}>{"  " + padEnd(i === 0 ? "checks" : "", 22)}</Text>
             <Text color={theme.dim}>{padEnd(c.name, 14)}</Text>

--- a/src/tui/Confirm.tsx
+++ b/src/tui/Confirm.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from "react";
 import type { Config, Target } from "../config.ts";
 import { bytes, count } from "../format.ts";
 import { type Preflight, preflight } from "../guards.ts";
-import { argvFor } from "../rsync.ts";
-import { padEnd, truncatePath } from "../width.ts";
+import { argvFor, glossArgv } from "../rsync.ts";
+import { padEnd, truncate, truncatePath } from "../width.ts";
 import { Rule, Screen } from "./Screen.tsx";
 import type { Theme } from "./theme.ts";
 
@@ -106,12 +106,41 @@ export function Confirm(props: ConfirmProps): React.ReactElement {
     </Box>
   );
 
+  // Showing the argv is what the page rests on; showing it in a form someone
+  // can act on is the point of showing it. `-a -A -X -i --out-format=…` is
+  // exact and unreadable, and a reader who cannot tell whether a flag deletes
+  // has not actually been told what will run.
+  const gloss = glossArgv(argv);
+  // Rows the rest of the page needs: title, the fields, the checks, the two
+  // rules, the paths and the keys — plus the blank line above the legend.
+  // Deliberately generous, because several of those rows wrap at a width and
+  // a path length this cannot see: a check detail, or the argv itself, can
+  // each take two lines. Ink clips rather than scrolls, so an overrun costs
+  // the top of the page — the unit being synced and the word `checks` — while
+  // an over-estimate costs only a legend that was never load-bearing.
+  const RESERVED_ROWS = 26;
+  const legend = height === undefined || height - RESERVED_ROWS >= gloss.length ? gloss : [];
+  const flagColumn = Math.min(28, Math.max(0, ...legend.map((g) => g.flag.length)));
+
   const footer = (
     <Box flexDirection="column">
       {/* The literal argv. Nothing runs that is not shown here first. */}
       <Text color={theme.dim}>{"  " + argv.slice(0, -2).join(" ")}</Text>
       <Text color={theme.dim}>{"      " + truncatePath(argv[argv.length - 2] ?? "", W - 8)}</Text>
       <Text color={theme.dim}>{"      " + truncatePath(argv[argv.length - 1] ?? "", W - 8)}</Text>
+      {legend.length === 0 ? null : (
+        <Box flexDirection="column">
+          <Text> </Text>
+          {legend.map((g, i) => (
+            // Keyed by position: a config listing the same exclude twice would
+            // otherwise collide.
+            <Box key={`${g.flag}-${i}`}>
+              <Text color={theme.ink}>{"  " + padEnd(g.flag, flagColumn + 2)}</Text>
+              <Text color={theme.dim}>{truncate(g.gloss, Math.max(10, W - flagColumn - 4))}</Text>
+            </Box>
+          ))}
+        </Box>
+      )}
       <Text> </Text>
       {pre !== null && !pre.ok ? (
         <Text color={theme.missing}>{"  blocked — a check failed. [esc] back"}</Text>

--- a/test/confirm.test.tsx
+++ b/test/confirm.test.tsx
@@ -7,7 +7,7 @@ import { freeBytes } from "../src/guards.ts";
 import { checkBuild, DEFAULT_RSYNC } from "../src/rsync.ts";
 import { SENTINEL_NAME, writeSentinel } from "../src/sentinel.ts";
 import { App } from "../src/tui/App.tsx";
-import { Confirm, replaceLine } from "../src/tui/Confirm.tsx";
+import { Confirm, nextCandidate, replaceLine } from "../src/tui/Confirm.tsx";
 import { Job } from "../src/tui/Job.tsx";
 import { THEMES } from "../src/tui/theme.ts";
 import { makeFixtureDir, removeFixtureDir, waitFor } from "./helpers.ts";
@@ -251,6 +251,128 @@ describeRsync("the argv is shown in words, not only in flags", () => {
     // The parts the page cannot drop.
     expect(frame).toContain("--partial-dir=.syncy-partial");
     expect(frame).toContain("[enter] run");
+  });
+});
+
+describe("cycling between destinations", () => {
+  const cs = [
+    { name: "ext", nChanges: 504, bytesPending: 100 },
+    { name: "nas", nChanges: 143, bytesPending: 200 },
+    { name: "offsite", nChanges: 7, bytesPending: 300 },
+  ];
+
+  test("moves to the next and wraps at the end", () => {
+    expect(nextCandidate(cs, "ext")).toBe("nas");
+    expect(nextCandidate(cs, "nas")).toBe("offsite");
+    expect(nextCandidate(cs, "offsite")).toBe("ext");
+  });
+
+  test("one destination is nowhere to go", () => {
+    expect(nextCandidate(cs.slice(0, 1), "ext")).toBeNull();
+    expect(nextCandidate(undefined, "ext")).toBeNull();
+    expect(nextCandidate([], "ext")).toBeNull();
+  });
+
+  test("a current destination not on the list is a disagreement, not a guess", () => {
+    expect(nextCandidate(cs, "somewhere-else")).toBeNull();
+  });
+});
+
+describeRsync("choosing which destination to sync", () => {
+  const candidates = [
+    { name: "dst", nChanges: 2, bytesPending: 7 },
+    { name: "second", nChanges: 143, bytesPending: 8_400_000_000 },
+  ];
+
+  function mountWithCandidates() {
+    let switched: string | null = null;
+    const r = render(
+      <Confirm
+        config={config}
+        unit="photos-2019"
+        target={target()}
+        candidates={candidates}
+        onSwitch={(name) => {
+          switched = name;
+        }}
+        nChanges={2}
+        nExtra={0}
+        bytesPending={7}
+        theme={THEMES.ansi}
+        width={100}
+        onRun={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    return { ...r, frame: () => plain(r.lastFrame()), switched: () => switched };
+  }
+
+  test("names the other destinations and what each is behind by", async () => {
+    const s = mountWithCandidates();
+    await settle();
+    expect(s.frame()).toContain("also behind: second 143 files");
+  });
+
+  test("offers the switch in the keys", async () => {
+    const s = mountWithCandidates();
+    await settle();
+    expect(s.frame()).toContain("[tab] switch to second");
+  });
+
+  test("tab asks for the next destination rather than running anything", async () => {
+    const s = mountWithCandidates();
+    await settle();
+    s.stdin.write("\t");
+    await settle(50);
+    expect(s.switched()).toBe("second");
+  });
+
+  test("a switch does not carry the previous destination's checks with it", async () => {
+    // The one that would actually be dangerous: `ok` gates the launch, so a
+    // preflight left over from the destination you just switched away from
+    // would let enter run a sync that nothing had checked.
+    mkdirSync(join(root, "dst2"), { recursive: true });
+    const id2 = await writeSentinel(join(root, "dst2"));
+    const second: Target = { ...target(), name: "second", path: join(root, "dst2"), sentinel: id2 };
+    let ran = false;
+    const props = {
+      config,
+      unit: "photos-2019",
+      candidates,
+      nChanges: 2,
+      nExtra: 0,
+      bytesPending: 7,
+      theme: THEMES.ansi,
+      width: 100,
+      onRun: () => {
+        ran = true;
+      },
+      onCancel: () => {},
+    };
+    const r = render(<Confirm {...props} target={target()} onSwitch={() => {}} />);
+    await settle();
+    // The first destination's checks have resolved and enter would run.
+    expect(plain(r.lastFrame())).toContain("dry run");
+
+    r.rerender(<Confirm {...props} target={second} onSwitch={() => {}} />);
+    r.stdin.write(ENTER);
+    expect(ran).toBe(false);
+    expect(plain(r.lastFrame())).toContain("running…");
+
+    // And once the new destination's own preflight lands, it is that one's.
+    await settle(400);
+    expect(plain(r.lastFrame())).toContain("dst2");
+  });
+
+  test("a single destination offers no switch, and tab does nothing", async () => {
+    const s = mountConfirm();
+    await settle();
+    expect(s.frame()).not.toContain("[tab]");
+    expect(s.frame()).not.toContain("also behind");
+    s.stdin.write("\t");
+    await settle(50);
+    expect(s.ran()).toBe(false);
+    expect(s.cancelled()).toBe(false);
   });
 });
 

--- a/test/confirm.test.tsx
+++ b/test/confirm.test.tsx
@@ -58,7 +58,11 @@ const target = (): Target => config.targets[0]!;
 
 function mountConfirm(
   bytesPending = 7,
-  over: { readonly nChanges?: number; readonly nNew?: number; readonly needsChecksum?: boolean } = {},
+  over: {
+    readonly nChanges?: number;
+    readonly nNew?: number;
+    readonly needsChecksum?: boolean;
+  } = {},
 ) {
   let ran = false;
   let cancelled = false;

--- a/test/confirm.test.tsx
+++ b/test/confirm.test.tsx
@@ -211,6 +211,49 @@ describeRsync("the confirm page separates creations from replacements", () => {
   });
 });
 
+describeRsync("the argv is shown in words, not only in flags", () => {
+  test("glosses the flags under the command", async () => {
+    const s = mountConfirm();
+    await settle();
+    expect(s.frame()).toContain("-a");
+    expect(s.frame()).toContain("recurse; keep times, permissions");
+    // Truncated to the column at this width, which is the point of the column.
+    expect(s.frame()).toContain("an interrupted file parks under");
+  });
+
+  test("still shows the literal argv, which is what actually runs", async () => {
+    const s = mountConfirm();
+    await settle();
+    expect(s.frame()).toContain("--partial-dir=.syncy-partial");
+  });
+
+  test("drops the legend rather than the checks on a window with no room", async () => {
+    // 26 rows fits the page and not the legend. Ink clips instead of
+    // scrolling, and what it clips is the top — the unit being synced.
+    const r = render(
+      <Confirm
+        config={config}
+        unit="photos-2019"
+        target={target()}
+        nChanges={2}
+        nExtra={3}
+        bytesPending={7}
+        theme={THEMES.ansi}
+        width={76}
+        height={26}
+        onRun={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    await settle();
+    const frame = plain(r.lastFrame());
+    expect(frame).not.toContain("recurse; keep times");
+    // The parts the page cannot drop.
+    expect(frame).toContain("--partial-dir=.syncy-partial");
+    expect(frame).toContain("[enter] run");
+  });
+});
+
 function mountJob(opts: { readonly bin?: string } = {}) {
   let result: { exitCode: number | null; cancelled: boolean; transferred: number } | null = null;
   let closed = false;

--- a/test/confirm.test.tsx
+++ b/test/confirm.test.tsx
@@ -7,7 +7,7 @@ import { freeBytes } from "../src/guards.ts";
 import { checkBuild, DEFAULT_RSYNC } from "../src/rsync.ts";
 import { SENTINEL_NAME, writeSentinel } from "../src/sentinel.ts";
 import { App } from "../src/tui/App.tsx";
-import { Confirm } from "../src/tui/Confirm.tsx";
+import { Confirm, replaceLine } from "../src/tui/Confirm.tsx";
 import { Job } from "../src/tui/Job.tsx";
 import { THEMES } from "../src/tui/theme.ts";
 import { makeFixtureDir, removeFixtureDir, waitFor } from "./helpers.ts";
@@ -56,7 +56,10 @@ afterEach(() => {
 
 const target = (): Target => config.targets[0]!;
 
-function mountConfirm(bytesPending = 7) {
+function mountConfirm(
+  bytesPending = 7,
+  over: { readonly nChanges?: number; readonly nNew?: number; readonly needsChecksum?: boolean } = {},
+) {
   let ran = false;
   let cancelled = false;
   const r = render(
@@ -64,7 +67,9 @@ function mountConfirm(bytesPending = 7) {
       config={config}
       unit="photos-2019"
       target={target()}
-      nChanges={2}
+      nChanges={over.nChanges ?? 2}
+      {...(over.nNew === undefined ? {} : { nNew: over.nNew })}
+      {...(over.needsChecksum === undefined ? {} : { needsChecksum: over.needsChecksum })}
       nExtra={3}
       bytesPending={bytesPending}
       theme={THEMES.ansi}
@@ -161,6 +166,48 @@ describeRsync("the confirm page refuses to launch when a check fails", () => {
     const s = mountConfirm();
     s.stdin.write(ENTER);
     expect(s.ran()).toBe(false);
+  });
+});
+
+describe("new versus replaced", () => {
+  test("says nothing is replaced when every file is a creation", () => {
+    expect(replaceLine(504, 504)).toBe("nothing — all 504 are new at the destination");
+  });
+
+  test("says all of them when every file is already there", () => {
+    expect(replaceLine(12, 0)).toBe("all 12 — every one is already there and differs");
+  });
+
+  test("splits a mixed transfer both ways", () => {
+    expect(replaceLine(504, 492)).toBe("12 of them · the other 492 are new at the destination");
+  });
+
+  test("offers no breakdown for a check written before nNew was tracked", () => {
+    expect(replaceLine(504, undefined)).toBeNull();
+  });
+});
+
+describeRsync("the confirm page separates creations from replacements", () => {
+  test("shows the split beside the transfer total", async () => {
+    const s = mountConfirm(7, { nChanges: 504, nNew: 492 });
+    await settle();
+    expect(s.frame()).toContain("will replace");
+    expect(s.frame()).toContain("12 of them");
+  });
+
+  test("omits the row entirely when there is no breakdown to show", async () => {
+    const s = mountConfirm();
+    await settle();
+    expect(s.frame()).not.toContain("will replace");
+  });
+
+  test("repair mode counts the files that actually differ", async () => {
+    // Not `nChanges`: announcing 504 files as differing by content, when 492
+    // of them are simply not there yet, is the reading this page had.
+    const s = mountConfirm(7, { nChanges: 504, nNew: 492, needsChecksum: true });
+    await settle();
+    expect(s.frame()).toContain("12 differ by content");
+    expect(s.frame()).not.toContain("504 differ by content");
   });
 });
 

--- a/test/rsync.test.ts
+++ b/test/rsync.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import { parseConfig, type Target } from "../src/config.ts";
 import { explainFlags } from "../src/itemize.ts";
-import { argvFor, assertDeleteIsDryRun, buildArgv, RsyncError } from "../src/rsync.ts";
+import {
+  argvFor,
+  assertDeleteIsDryRun,
+  buildArgv,
+  glossArgv,
+  type Mode,
+  RsyncError,
+} from "../src/rsync.ts";
 
 const target = (over: Partial<Target> = {}): Target => ({
   name: "nas",
@@ -227,5 +234,73 @@ describe("explaining an itemize string", () => {
   test("xattr and acl columns are read from the right positions", () => {
     expect(explainFlags(".f........x")).toBe("xattr");
     expect(explainFlags(".f.......a.")).toBe("acl");
+  });
+});
+
+describe("the argv in words", () => {
+  /**
+   * Every flag `buildArgv` can emit, across every mode and every destination
+   * shape that changes the command. This is the guarantee: a flag added to
+   * buildArgv without a gloss fails here, rather than reaching the confirm
+   * page as a bare `--whatever` under a heading promising the reader has been
+   * shown what will run.
+   */
+  const everyArgv = (): string[][] => {
+    const modes: Mode[] = ["quick", "deep", "sync"];
+    const targets = [
+      target(),
+      target({ flagsDrop: ["-p", "-A", "-X"] }),
+      target({ fstype: "exfat", modifyWindow: 2 }),
+    ];
+    const out: string[][] = [];
+    for (const m of modes) {
+      for (const t of targets) {
+        out.push(buildArgv(m, "/src/x", t, [".DS_Store", "._*"]));
+        out.push(buildArgv(m, "/src/x", t, [".DS_Store"], { checksum: true }));
+      }
+    }
+    return out;
+  };
+
+  test("every flag buildArgv can produce has an explanation", () => {
+    for (const argv of everyArgv()) {
+      const flags = argv.slice(0, -2);
+      const glossed = new Set(glossArgv(argv).map((g) => g.flag));
+      for (const f of flags) {
+        expect(glossed.has(f)).toBe(true);
+      }
+    }
+  });
+
+  test("the two path arguments are left out — the screens show them separately", () => {
+    const argv = buildArgv("sync", "/src/x", target(), []);
+    const flags = glossArgv(argv).map((g) => g.flag);
+    expect(flags).not.toContain("/src/x/");
+    expect(flags).not.toContain("/Volumes/media/archive/photos/2019/");
+  });
+
+  test("--delete is described as listing only when -n is actually present", () => {
+    const quick = glossArgv(buildArgv("quick", "/src/x", target(), []));
+    const del = quick.find((g) => g.flag === "--delete");
+    expect(del?.gloss).toContain("deletes nothing");
+  });
+
+  test("--delete without -n is described as deleting", () => {
+    // buildArgv never produces this pair, and assertDeleteIsDryRun refuses it
+    // at spawn. The gloss must not be the one place that calls it harmless.
+    const g = glossArgv(["-a", "--delete", "/src/", "/dst/"]);
+    expect(g.find((x) => x.flag === "--delete")?.gloss).toContain("DELETES");
+  });
+
+  test("the patterned flags read back the value they carry", () => {
+    const argv = buildArgv("quick", "/src/x", target({ modifyWindow: 2 }), ["._*"]);
+    const by = new Map(glossArgv(argv).map((g) => [g.flag, g.gloss]));
+    expect(by.get("--modify-window=2")).toContain("within 2s");
+    expect(by.get("--exclude=._*")).toContain("._*");
+    expect(by.get("--exclude=.syncy-*")).toContain("syncy's own");
+  });
+
+  test("a flag with no gloss is dropped rather than shown blank", () => {
+    expect(glossArgv(["-a", "--zz-unknown", "/src/", "/dst/"]).map((g) => g.flag)).toEqual(["-a"]);
   });
 });

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -105,6 +105,47 @@ describe("cell state ladder", () => {
     expect(c.reason).toBe("143 files pending");
   });
 
+  test("behind carries the new/replaced breakdown when the check recorded one", () => {
+    const s = scan({ outcome: "behind", method: "deep", nChanges: 504, nNew: 492 });
+    expect(cell({ latest: s, deep: s }).nNew).toBe(492);
+  });
+
+  test("a deep verify whose differences are all creations needs no checksum sync", () => {
+    // The screenshot case: 504 files absent from the destination, found by a
+    // deep verify. rsync copies a file that is not there whatever it compares
+    // by, so `-c` buys nothing and the confirm page must not announce that
+    // these differ by content.
+    const s = scan({ outcome: "behind", method: "deep", nChanges: 504, nNew: 504 });
+    const c = cell({ latest: s, deep: s });
+    expect(c.needsChecksum).toBeUndefined();
+    expect(c.reason).toBe("504 files not copied yet");
+  });
+
+  test("a deep verify with any content drift still needs a checksum sync", () => {
+    const s = scan({ outcome: "behind", method: "deep", nChanges: 504, nNew: 503 });
+    expect(cell({ latest: s, deep: s }).needsChecksum).toBe(true);
+  });
+
+  test("a record with no breakdown keeps the conservative reading", () => {
+    // nNew predates the field, so the method is the only evidence there is.
+    const s = scan({ outcome: "behind", method: "deep", nChanges: 504 });
+    const c = cell({ latest: s, deep: s });
+    expect(c.needsChecksum).toBe(true);
+    expect(c.nNew).toBeUndefined();
+  });
+
+  test("a quick check never asks for a checksum sync", () => {
+    const s = scan({ outcome: "behind", method: "quick", nChanges: 5, nNew: 0 });
+    expect(cell({ latest: s, quick: s }).needsChecksum).toBeUndefined();
+  });
+
+  test("missing counts every file as new, since nothing is there to replace", () => {
+    const s = scan({ outcome: "missing", method: "quick" });
+    const c = cell({ latest: s, quick: s });
+    expect(c.nNew).toBe(FP.nfiles);
+    expect(c.nChanges).toBe(FP.nfiles);
+  });
+
   test("error surfaces rather than being swallowed as unknown", () => {
     const s = scan({ outcome: "error", method: "quick" });
     expect(cell({ latest: s, quick: s }).state).toBe("error");


### PR DESCRIPTION
Three changes to the page `s` opens, each a separate commit. All three came out of reading the page against a real folder — `24-01-01 - 2024` → External, 504 files behind — and finding it said things that were not true, or not enough to decide on.

## Separate what a sync creates from what it overwrites

The page said `will transfer 504 files · 5.8 gb` and, above it, `repair mode — these differ by content`. All 504 were absent from the destination. Nothing was going to be overwritten.

`Cell` now carries `nNew` from the scan record, so the page can say `will replace  nothing — all 504 are new at the destination`. `needsChecksum` is set from what the check *found* rather than from the method alone: a deep verify whose every difference is a creation needs no `-c`, since rsync copies a missing file whatever it compares by. That sync was reading 13 gb of source to decide about files that were not there.

Records predating `nNew` show no row and keep the older, conservative reading.

## Say what each rsync flag does, next to the flag

The page's promise is that nothing runs that is not shown there first. `-a -A -X -i --out-format=%i|%l|%M|%n` satisfies the letter of that and tells someone deciding whether to write to a drive nothing they can act on.

The literal argv is unchanged, with a glossed legend under it. `glossArgv` sits beside the `buildArgv` that emits the flags, and a test walks every mode and destination shape `buildArgv` can produce, failing on any flag without a gloss. `--delete` reads its own company: with `-n` it says it lists and deletes nothing, without it says it DELETES.

On a window too short for the page the legend is dropped — never the argv, the checks or the keys.

## Let the confirm page choose which destination to sync

`s` took the first behind-or-missing destination and offered no way to reach another, so with two behind, the second could not be synced until the first was clean. The ledger's cursor moves over folders, which is right for every other key — `enter` and `q`/`d` act on all destinations — and `s` is the only one needing a single destination, so the choice goes on the page where the decision is made.

`tab` moves between the destinations the folder is behind on; counts, repair mode, checks and argv all re-derive. The preflight is stamped with the destination it ran against: `ok` gates the launch, and a result carried across a switch would have cleared a sync that nothing had checked.

## Verified

883 tests pass (24 new), `tsc` and `biome` clean, checked in a clean worktree containing only these three commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)