### PR TITLE
Confine canonical destinations and sync logs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
-import { isAbsolute, resolve, sep } from "node:path";
+import { readFileSync, realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
 
 /**
  * Runtime validation is mandatory, not optional (DESIGN.md §1).
@@ -121,6 +121,60 @@ function absolutePath(value: string, where: string): string {
   return resolve(value);
 }
 
+/**
+ * Resolves a path through symlinks when it exists.
+ *
+ * Lexical path checks are not enough for the safety boundary: `/backup` can
+ * be a symlink into `/source`, and two differently spelled paths can name the
+ * same directory. A config may legitimately be loaded before a source or
+ * target exists, so a failed realpath is represented as null and the runtime
+ * executor repeats the check once both sides are reachable.
+ */
+export function canonicalPath(path: string): string | null {
+  let current = resolve(path);
+  const suffix: string[] = [];
+  try {
+    return realpathSync(current);
+  } catch {
+    // A target folder may not exist yet, but a symlink in one of its parents
+    // can still put it inside the source. Resolve the nearest existing parent
+    // and append the missing suffix lexically.
+    while (true) {
+      const parent = dirname(current);
+      if (parent === current) return null;
+      suffix.unshift(basename(current));
+      current = parent;
+      try {
+        return suffix.reduce((base, part) => join(base, part), realpathSync(current));
+      } catch {
+        // Keep walking toward the root until an existing ancestor is found.
+      }
+    }
+  }
+}
+
+/**
+ * Returns the containment error for a source/target pair, if any.
+ *
+ * The lexical check covers paths that do not exist yet. When both paths are
+ * present, the canonical check closes the symlink-alias hole as well.
+ */
+export function containmentError(source: string, target: string): string | null {
+  if (isWithin(target, source)) return `target is inside the source root (${source})`;
+  if (isWithin(source, target)) return `source root is inside this target (${target})`;
+
+  const canonicalSource = canonicalPath(source);
+  const canonicalTarget = canonicalPath(target);
+  if (canonicalSource === null || canonicalTarget === null) return null;
+  if (isWithin(canonicalTarget, canonicalSource)) {
+    return `target is inside the source root (${source})`;
+  }
+  if (isWithin(canonicalSource, canonicalTarget)) {
+    return `source root is inside this target (${target})`;
+  }
+  return null;
+}
+
 /** True when `inner` is the same as, or nested beneath, `outer`. */
 export function isWithin(inner: string, outer: string): boolean {
   const a = resolve(inner);
@@ -171,6 +225,7 @@ export function parseConfig(text: string): Config {
 
   const seenNames = new Set<string>();
   const seenPaths = new Set<string>();
+  const seenCanonicalPaths = new Set<string>();
   const targets: Target[] = targetsRaw.map((entry, i) => {
     const where = `target[${i}]`;
     if (!isRecord(entry)) throw new ConfigError(where, "expected a table");
@@ -185,13 +240,17 @@ export function parseConfig(text: string): Config {
       throw new ConfigError(`${where}.path`, `duplicate target path "${path}"`);
     seenPaths.add(path);
 
+    const canonicalTarget = canonicalPath(path);
+    if (canonicalTarget !== null) {
+      if (seenCanonicalPaths.has(canonicalTarget)) {
+        throw new ConfigError(`${where}.path`, `duplicate target path "${path}"`);
+      }
+      seenCanonicalPaths.add(canonicalTarget);
+    }
+
     // Nested source and target is data loss waiting to happen (DESIGN.md §7).
-    if (isWithin(path, source)) {
-      throw new ConfigError(`${where}.path`, `target is inside the source root (${source})`);
-    }
-    if (isWithin(source, path)) {
-      throw new ConfigError(`${where}.path`, `source root is inside this target (${path})`);
-    }
+    const nested = containmentError(source, path);
+    if (nested !== null) throw new ConfigError(`${where}.path`, nested);
 
     const identity =
       typeof entry["identity"] === "string" ? (entry["identity"] as string) : undefined;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { join, relative, resolve, sep } from "node:path";
-import { canonicalPath, containmentError, type Config, type Target } from "./config.ts";
+import { type Config, canonicalPath, containmentError, type Target } from "./config.ts";
 import { type Item, parseItemizeLine } from "./itemize.ts";
 import { debug } from "./log.ts";
 import { argvFor, assertDeleteIsDryRun, DEFAULT_RSYNC, RsyncError } from "./rsync.ts";

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
-import { join } from "node:path";
-import type { Config, Target } from "./config.ts";
+import { join, relative, resolve, sep } from "node:path";
+import { canonicalPath, containmentError, type Config, type Target } from "./config.ts";
 import { type Item, parseItemizeLine } from "./itemize.ts";
 import { debug } from "./log.ts";
 import { argvFor, assertDeleteIsDryRun, DEFAULT_RSYNC, RsyncError } from "./rsync.ts";
@@ -39,9 +39,52 @@ export interface SyncOptions {
   readonly now?: number;
 }
 
+/** A log filename component that cannot introduce a path separator or `..`. */
+function safeLogPart(value: string): string {
+  return value
+    .replace(/[^A-Za-z0-9._-]/g, (c) => `%${c.codePointAt(0)!.toString(16).padStart(2, "0")}`)
+    .replace(/\.\./g, "%2e%2e");
+}
+
 export function syncLogPath(unit: string, target: string, now: number): string {
   const stamp = new Date(now).toISOString().replace(/[:.]/g, "-");
-  return join(ensureLogDir(), `${stamp}-${unit.replace(/\//g, "_")}-${target}.log`);
+  return join(ensureLogDir(), `${stamp}-${safeLogPart(unit)}-${safeLogPart(target)}.log`);
+}
+
+/**
+ * A caller-provided log path is still a syncy-owned write and must stay under
+ * the state log directory. The default is encoded by `syncLogPath`; this check
+ * keeps the optional test/integration seam from becoming an escape hatch.
+ */
+function assertLogPath(logPath: string): void {
+  const dir = resolve(ensureLogDir());
+  const candidate = resolve(logPath);
+  // Resolve existing symlinks in the state tree as well. A lexical child of
+  // `logs/` can otherwise be a link to a file elsewhere, which would turn the
+  // optional logPath seam into a write outside syncy's own state.
+  const canonicalDir = canonicalPath(dir) ?? dir;
+  const canonicalCandidate = canonicalPath(candidate) ?? candidate;
+  const rel = relative(canonicalDir, canonicalCandidate);
+  if (rel === "" || rel === ".." || rel.startsWith(`..${sep}`) || rel.startsWith(sep)) {
+    throw new RsyncError(`refusing to write sync log outside ${dir}: ${logPath}`);
+  }
+}
+
+/**
+ * Rechecks path containment at execution time, after symlinks and mounts have
+ * settled. Config parsing catches the common case, but a target can be
+ * replaced with a symlink while the application is open.
+ */
+function assertRuntimeContainment(config: Config, target: Target): void {
+  const lexical = containmentError(config.source, target.path);
+  if (lexical !== null) throw new RsyncError(`refusing to sync: ${lexical}`);
+  const source = canonicalPath(config.source);
+  const destination = canonicalPath(target.path);
+  if (source === null || destination === null) {
+    throw new RsyncError("refusing to sync: source or destination cannot be resolved");
+  }
+  const canonical = containmentError(source, destination);
+  if (canonical !== null) throw new RsyncError(`refusing to sync: ${canonical}`);
 }
 
 /**
@@ -70,7 +113,9 @@ export function startSync(
   // as far as spawning if the invariant is broken.
   assertDeleteIsDryRun(argv);
 
+  assertRuntimeContainment(config, target);
   const logPath = opts.logPath ?? syncLogPath(unit, target.name, now);
+  assertLogPath(logPath);
   appendHistory({ ts: now, unit, target: target.name, argv, exitCode: null, log: logPath });
 
   // No mkdir: rsync creates the destination itself. syncy writes directly

--- a/src/tui/Confirm.tsx
+++ b/src/tui/Confirm.tsx
@@ -232,7 +232,12 @@ export function Confirm(props: ConfirmProps): React.ReactElement {
           // Named, with their own figures, rather than a bare "2 others": the
           // point of showing them is to make the choice between them, and
           // "NAS · 143 files" is what that choice is made on.
-          <Text color={theme.dim}>{truncate(`   also behind: ${others}`, Math.max(10, W - unit.length - target.name.length - 12))}</Text>
+          <Text color={theme.dim}>
+            {truncate(
+              `   also behind: ${others}`,
+              Math.max(10, W - unit.length - target.name.length - 12),
+            )}
+          </Text>
         )}
       </Box>
       <Rule width={W} theme={theme} />

--- a/src/tui/Setup.tsx
+++ b/src/tui/Setup.tsx
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { Box, Text, useInput } from "ink";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { canonicalPath, containmentError, type Config, type Target } from "../config.ts";
+import { type Config, canonicalPath, containmentError, type Target } from "../config.ts";
 import { saveConfig, withoutTarget, withTarget } from "../configio.ts";
 import { bytes } from "../format.ts";
 import { type MountEntry, modifyWindowFor } from "../fstype.ts";

--- a/src/tui/Setup.tsx
+++ b/src/tui/Setup.tsx
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { Box, Text, useInput } from "ink";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { type Config, isWithin, type Target } from "../config.ts";
+import { canonicalPath, containmentError, type Config, type Target } from "../config.ts";
 import { saveConfig, withoutTarget, withTarget } from "../configio.ts";
 import { bytes } from "../format.ts";
 import { type MountEntry, modifyWindowFor } from "../fstype.ts";
@@ -85,13 +85,22 @@ export function validateTargetPath(path: string, config: Config): string | null 
   } catch {
     return "cannot read that path";
   }
-  // Nested source and target is data loss waiting to happen. Skipped when no
-  // source is set yet, since resolve("") would silently mean the cwd.
+  // Nested source and target is data loss waiting to happen. The shared check
+  // compares both lexical and canonical paths, so a symlink alias cannot make
+  // an apparently separate destination point back into the source.
   if (config.source !== "") {
-    if (isWithin(abs, config.source)) return "inside the source root";
-    if (isWithin(config.source, abs)) return "contains the source root";
+    const nested = containmentError(config.source, abs);
+    if (nested?.startsWith("target is inside")) return "inside the source root";
+    if (nested?.startsWith("source root is inside")) return "contains the source root";
   }
-  if (config.targets.some((t) => t.path === abs)) return "already a destination";
+  const canonical = canonicalPath(abs);
+  if (
+    config.targets.some(
+      (t) => t.path === abs || (canonical !== null && canonicalPath(t.path) === canonical),
+    )
+  ) {
+    return "already a destination";
+  }
   return null;
 }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { mkdirSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
 import { ConfigError, isWithin, parseConfig } from "../src/config.ts";
+import { makeFixtureDir, removeFixtureDir } from "./helpers.ts";
 
 const VALID = `
 source = "/Users/you/Pictures/Archive"
@@ -182,6 +185,40 @@ sentinel = "s"
 
   test("malformed TOML", () => {
     expectError(`source = "unterminated\n`, "not valid TOML");
+  });
+
+  test("a symlinked target that resolves inside the source is rejected", () => {
+    const root = makeFixtureDir("syncy-config-symlink");
+    try {
+      const source = join(root, "source");
+      const target = join(root, "target-alias");
+      mkdirSync(source, { recursive: true });
+      symlinkSync(source, target, "dir");
+      expectError(
+        `source = "${source}"\n[[target]]\nname = "alias"\npath = "${target}"\nsentinel = "s"\n`,
+        "inside the source root",
+      );
+    } finally {
+      removeFixtureDir(root);
+    }
+  });
+
+  test("two target paths that are symlink aliases are rejected as duplicates", () => {
+    const root = makeFixtureDir("syncy-config-aliases");
+    try {
+      const source = join(root, "source");
+      const first = join(root, "first");
+      const second = join(root, "second");
+      mkdirSync(source, { recursive: true });
+      mkdirSync(first, { recursive: true });
+      symlinkSync(first, second, "dir");
+      expectError(
+        `source = "${source}"\n[[target]]\nname = "one"\npath = "${first}"\nsentinel = "a"\n[[target]]\nname = "two"\npath = "${second}"\nsentinel = "b"\n`,
+        "duplicate target path",
+      );
+    } finally {
+      removeFixtureDir(root);
+    }
   });
 });
 

--- a/test/confirm.test.tsx
+++ b/test/confirm.test.tsx
@@ -58,7 +58,11 @@ const target = (): Target => config.targets[0]!;
 
 function mountConfirm(
   bytesPending = 7,
-  over: { readonly nChanges?: number; readonly nNew?: number; readonly needsChecksum?: boolean } = {},
+  over: {
+    readonly nChanges?: number;
+    readonly nNew?: number;
+    readonly needsChecksum?: boolean;
+  } = {},
 ) {
   let ran = false;
   let cancelled = false;

--- a/test/setup.test.ts
+++ b/test/setup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { type Config, parseConfig, type Target } from "../src/config.ts";
 import {
@@ -169,6 +169,25 @@ describe("target path validation", () => {
   test("accepts a good path", () => {
     mkdirSync(join(root, "dst"), { recursive: true });
     expect(validateTargetPath(join(root, "dst"), EMPTY_CONFIG("/src"))).toBeNull();
+  });
+
+  test("rejects a symlink alias that resolves inside the source", () => {
+    const source = join(root, "src");
+    const alias = join(root, "dst-alias");
+    mkdirSync(source, { recursive: true });
+    symlinkSync(source, alias, "dir");
+    expect(validateTargetPath(alias, EMPTY_CONFIG(source))).toBe("inside the source root");
+  });
+
+  test("rejects a symlink alias of an existing destination", () => {
+    const source = join(root, "src");
+    const destination = join(root, "dst");
+    const alias = join(root, "dst-alias");
+    mkdirSync(source, { recursive: true });
+    mkdirSync(destination, { recursive: true });
+    symlinkSync(destination, alias, "dir");
+    const config = withTarget(EMPTY_CONFIG(source), target({ path: destination }));
+    expect(validateTargetPath(alias, config)).toBe("already a destination");
   });
 });
 

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -18,7 +18,7 @@ import { checkUnit } from "../src/scan.ts";
 import { SENTINEL_NAME, writeSentinel } from "../src/sentinel.ts";
 import type { Scan } from "../src/state.ts";
 import { cellState } from "../src/status.ts";
-import { startSync } from "../src/sync.ts";
+import { startSync, syncLogPath } from "../src/sync.ts";
 import { makeFixtureDir, removeFixtureDir } from "./helpers.ts";
 
 const build = await checkBuild(DEFAULT_RSYNC);
@@ -208,6 +208,19 @@ describeRsync("a first copy states what it will actually move", () => {
 });
 
 describeRsync("startSync", () => {
+  test("encodes unit and target names before building a log path", () => {
+    const path = syncLogPath("../unit/with spaces", "../../target", Date.now());
+    expect(path).toContain("/state/syncy/logs/");
+    expect(path).not.toContain("../");
+    expect(path.endsWith(".log")).toBe(true);
+  });
+
+  test("rejects a caller-provided log path outside syncy's state", () => {
+    expect(() =>
+      startSync(config, "photos-2019", target(), { logPath: join(root, "outside.log") }),
+    ).toThrow(/outside/);
+  });
+
   test("copies the unit to the target", async () => {
     const h = startSync(config, "photos-2019", target());
     const r = await h.done;


### PR DESCRIPTION
Closes #17.

## What changed

- Resolve existing paths and their nearest existing ancestors before containment checks.
- Reject symlink aliases that nest a destination inside its source or duplicate another destination.
- Apply the same canonical checks in setup and again at the sync execution boundary.
- Encode target-derived log filename components and confine caller-provided log paths to syncy's log directory.

## Verification

- `bun test` — 889 passed, 0 failed
- `bunx tsc --noEmit`
- `bun run build`
- `bun run audit`

## Stack

Depends on #20 because the audit implementation was developed on its confirmed-page changes. The next audit PR is based on this branch.
