### PR TITLE
Make source fingerprints complete evidence

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -412,6 +412,12 @@ launch when the sentinel is missing or mismatched, when free space is under
 row reads `no · this writes to the target` on a real sync — stated, never
 implied.
 
+The preflight shown on the confirm page is a user-facing snapshot, not write
+permission. The executor asks the OS for the destination's current identity
+again, without the status mount-table cache, immediately before spawning the
+only process that can write. A drive removed or replaced while the page is
+open therefore refuses at the write boundary too.
+
 A folder can be behind on more than one destination, and `s` names only one of
 them. The confirm page lists the others with what each is behind by, and `tab`
 moves between them — the counts, the checks and the argv all re-derive. The

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -149,8 +149,11 @@ This is enforced, not documented: a test reads every file under `src/` and fails
 on any direct filesystem write outside a short allow list of modules that own
 syncy's own directories.
 
-**Source fingerprint** — `(nfiles, total_bytes, max_mtime_ns)` from a
-synchronous `opendirSync` walk of the unit. Metadata-only, ~2 s per 100k files.
+**Source fingerprint** — the legacy counters `(nfiles, total_bytes,
+max_mtime_ns)` plus a SHA-256 digest of a deterministic, sorted stream of each
+relative path's type, size and mtime (including symlinks), from a synchronous
+`opendirSync` walk of the unit. Metadata-only, ~2 s per 100k files. A walk that
+cannot read every entry is marked incomplete and is never accepted as evidence.
 Stored with every scan so a later run can ask *"has the source changed since I
 verified this?"* without touching the destination at all. This is what makes a
 stale verify detectable while the NAS is offline.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ is a writable directory on the boot disk, so a path check would let rsync fill
 the startup volume with the data you were moving off it. An unmounted path
 resolves to the boot volume, whose identity does not match.
 
+The confirmation page's reachability result is only a snapshot. The sync
+executor performs a fresh, uncached OS identity check immediately before it
+spawns rsync, so unplugging or replacing a destination while the page is open
+blocks the write as well.
+
 A sentinel file (`.syncy-dest-id` at the destination root) is available as an
 alternative. It is the stronger check — it also catches the destination
 directory being deleted and recreated, which volume identity cannot see — but it

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ own palette.
 ## Development
 
 ```
-bun test               # 845 tests
+bun test               # 900 tests
 bunx tsc --noEmit
 bun run build
 bun run audit          # no machine-specific data in the tree or the history

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "dependencies": {
         "ink": "^7.1.1",
         "react": "^19.2.8",
-        "react-devtools-core": "^7.0.1",
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "ink": "^7.1.1",
-    "react": "^19.2.8",
-    "react-devtools-core": "^7.0.1"
+    "react": "^19.2.8"
   }
 }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -28,26 +28,55 @@ function nativeTarget(): Target {
   return target;
 }
 
-function build(target: Target, outfile: string): void {
-  const result = Bun.spawnSync(
-    [
-      "bun",
-      "build",
-      "--compile",
-      "--minify",
-      `--target=${target}`,
-      "src/cli.ts",
-      `--outfile=${outfile}`,
-    ],
-    { stdout: "inherit", stderr: "inherit" },
-  );
-  if (result.exitCode !== 0) process.exit(result.exitCode ?? 1);
+/**
+ * Ink keeps its optional DevTools integration behind `DEV=true`, but Bun's
+ * bundler cannot prove that a runtime environment variable is false. The
+ * resulting production executable used to carry the DevTools client (and its
+ * optional react-devtools-core import) even though syncy never enables it.
+ * Patch both upstream development guards in the build graph (DevTools and
+ * development renderer metadata); node_modules itself is never modified, and
+ * development-only behavior cannot enter the release bundle.
+ */
+const noInkDevtools: Bun.BunPlugin = {
+  name: "syncy-production-ink",
+  setup(build) {
+    build.onLoad({ filter: /reconciler/ }, async (args) => {
+      if (!/[\\/]ink[\\/]build[\\/]reconciler\.js$/.test(args.path)) return;
+      const source = await Bun.file(args.path).text();
+      const guard = "if (process.env['DEV'] === 'true') {";
+      const guardCount = source.split(guard).length - 1;
+      if (guardCount !== 2) {
+        throw new Error(`expected two Ink development guards in ${args.path}; found ${guardCount}`);
+      }
+      return { contents: source.replaceAll(guard, "if (false) {"), loader: "js" };
+    });
+  },
+};
+
+async function build(target: Target, outfile: string): Promise<void> {
+  const result = await Bun.build({
+    entrypoints: ["src/cli.ts"],
+    target: "bun",
+    minify: true,
+    // React's development reconciler is several hundred kilobytes and
+    // carries diagnostics useful only while developing. Defining the
+    // condition explicitly selects React's lean runtime even if a developer
+    // has NODE_ENV set differently in their shell.
+    define: { "process.env.NODE_ENV": JSON.stringify("production") },
+    external: ["react-devtools-core"],
+    plugins: [noInkDevtools],
+    compile: { target, outfile },
+  });
+  if (!result.success) {
+    for (const log of result.logs) console.error(log);
+    process.exit(1);
+  }
 }
 
 const args = process.argv.slice(2);
 
 if (args.includes("--all")) {
-  for (const target of TARGETS) build(target, `syncy-${target}`);
+  for (const target of TARGETS) await build(target, `syncy-${target}`);
 } else {
   const flag = args.find((a) => a.startsWith("--target="));
   if (flag !== undefined) {
@@ -55,8 +84,8 @@ if (args.includes("--all")) {
     if (!(TARGETS as readonly string[]).includes(target)) {
       throw new Error(`unknown target ${target}; expected one of ${TARGETS.join(", ")}`);
     }
-    build(target, `syncy-${target}`);
+    await build(target, `syncy-${target}`);
   } else {
-    build(nativeTarget(), "syncy");
+    await build(nativeTarget(), "syncy");
   }
 }

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -95,6 +95,55 @@ export interface Diff {
  */
 export const MAX_ENTRIES = 1000;
 
+/**
+ * Bounded streaming state for an itemize pass.
+ *
+ * A check can visit hundreds of thousands of files. Keeping every parsed
+ * `Item` and then mapping it to a second `DiffEntry[]` made peak memory grow
+ * with the archive even though the differences screen stores only the first
+ * MAX_ENTRIES. This accumulator keeps exact totals while retaining only the
+ * entries the screen can display.
+ */
+export interface DiffAccumulator {
+  readonly entries: readonly DiffEntry[];
+  readonly totals: Readonly<Record<DiffKind, number>>;
+  readonly truncated: number;
+  readonly add: (item: Item) => void;
+}
+
+function entryFromItem(item: Item, kind: DiffKind): DiffEntry {
+  return {
+    kind,
+    name: item.name,
+    bytes: item.bytes,
+    flags: item.flags,
+    dir: kind !== "extra" && item.flags[1] === "d",
+    sized: kind !== "extra",
+    ...(item.mtime !== null ? { mtime: item.mtime } : {}),
+  };
+}
+
+/** Creates a collector that never stores more than MAX_ENTRIES differences. */
+export function createDiffAccumulator(): DiffAccumulator {
+  const entries: DiffEntry[] = [];
+  const totals: Record<DiffKind, number> = { new: 0, changed: 0, metadata: 0, extra: 0 };
+  let total = 0;
+  return {
+    entries,
+    totals,
+    get truncated() {
+      return Math.max(0, total - MAX_ENTRIES);
+    },
+    add(item) {
+      const kind = classify(item);
+      if (kind === null) return;
+      totals[kind] += 1;
+      total += 1;
+      if (entries.length < MAX_ENTRIES) entries.push(entryFromItem(item, kind));
+    },
+  };
+}
+
 export function classify(item: Item): DiffKind | null {
   if (item.kind === "same") return null;
   if (item.kind === "extra") return "extra";
@@ -102,6 +151,33 @@ export function classify(item: Item): DiffKind | null {
   // Shared with `summarize`, so the ledger's count and this listing can never
   // describe the same rsync run differently.
   return isNew(item) ? "new" : "changed";
+}
+
+export function buildDiffFromAccumulator(
+  unit: string,
+  target: string,
+  method: string,
+  accumulator: DiffAccumulator,
+  opts: {
+    readonly ts?: number;
+    readonly wholeFolderMissing?: boolean;
+    readonly source?: Fingerprint;
+    readonly target?: Fingerprint | null;
+  } = {},
+): Diff {
+  return {
+    version: 1,
+    totals: { ...accumulator.totals },
+    unit,
+    target,
+    ts: opts.ts ?? Date.now(),
+    method,
+    entries: accumulator.entries.slice(),
+    truncated: accumulator.truncated,
+    wholeFolderMissing: opts.wholeFolderMissing ?? false,
+    ...(opts.source !== undefined ? { sourceHolds: opts.source } : {}),
+    ...(opts.target != null ? { targetHolds: opts.target } : {}),
+  };
 }
 
 export function buildDiff(
@@ -116,35 +192,9 @@ export function buildDiff(
     readonly target?: Fingerprint | null;
   } = {},
 ): Diff {
-  const all: DiffEntry[] = [];
-  for (const it of items) {
-    const kind = classify(it);
-    if (kind === null) continue;
-    all.push({
-      kind,
-      name: it.name,
-      bytes: it.bytes,
-      flags: it.flags,
-      dir: kind !== "extra" && it.flags[1] === "d",
-      sized: kind !== "extra",
-      ...(it.mtime !== null ? { mtime: it.mtime } : {}),
-    });
-  }
-  const totals: Record<DiffKind, number> = { new: 0, changed: 0, metadata: 0, extra: 0 };
-  for (const e of all) totals[e.kind] += 1;
-  return {
-    version: 1,
-    totals,
-    unit,
-    target,
-    ts: opts.ts ?? Date.now(),
-    method,
-    entries: all.slice(0, MAX_ENTRIES),
-    truncated: Math.max(0, all.length - MAX_ENTRIES),
-    wholeFolderMissing: opts.wholeFolderMissing ?? false,
-    ...(opts.source !== undefined ? { sourceHolds: opts.source } : {}),
-    ...(opts.target != null ? { targetHolds: opts.target } : {}),
-  };
+  const accumulator = createDiffAccumulator();
+  for (const item of items) accumulator.add(item);
+  return buildDiffFromAccumulator(unit, target, method, accumulator, opts);
 }
 
 /**

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -1,4 +1,5 @@
-import { type Dir, opendirSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { type Dir, lstatSync, opendirSync, readlinkSync } from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -14,9 +15,33 @@ export interface Fingerprint {
   readonly nfiles: number;
   readonly bytes: number;
   readonly maxMtimeNs: string; // bigint as string; JSON has no bigint
+  /** SHA-256 of the sorted relative tree metadata, when produced by v2+. */
+  readonly digest?: string;
+  /** False means the walk could not establish a complete view of the tree. */
+  readonly complete?: boolean;
 }
 
-export const EMPTY: Fingerprint = { nfiles: 0, bytes: 0, maxMtimeNs: "0" };
+/** Read-only filesystem seam used to prove incomplete-walk handling. */
+export interface FingerprintIo {
+  readonly lstat: (path: string) => { readonly size: bigint; readonly mtimeNs: bigint };
+  readonly open: (path: string) => Dir;
+  readonly readlink: (path: string) => string;
+}
+
+const realFingerprintIo: FingerprintIo = {
+  lstat: (path) => lstatSync(path, { bigint: true }),
+  open: (path) => opendirSync(path),
+  readlink: (path) => readlinkSync(path),
+};
+
+const EMPTY_DIGEST = createHash("sha256").digest("hex");
+export const EMPTY: Fingerprint = {
+  nfiles: 0,
+  bytes: 0,
+  maxMtimeNs: "0",
+  digest: EMPTY_DIGEST,
+  complete: true,
+};
 
 /**
  * Basename matcher supporting a single leading and/or trailing `*`.
@@ -38,45 +63,103 @@ export function matchesAny(name: string, patterns: readonly string[]): boolean {
   return false;
 }
 
-export function fingerprint(root: string, exclude: readonly string[] = []): Fingerprint {
+export function fingerprint(
+  root: string,
+  exclude: readonly string[] = [],
+  io: FingerprintIo = realFingerprintIo,
+): Fingerprint {
   let nfiles = 0;
   let bytes = 0;
   let maxMtime = 0n;
+  let complete = true;
+  const digest = createHash("sha256");
 
-  const walk = (dir: string): void => {
+  /** Hash a record with unambiguous field boundaries. */
+  const record = (
+    kind: string,
+    name: string,
+    size: bigint,
+    mtimeNs: bigint,
+    linkTarget?: string,
+  ): void => {
+    digest.update(
+      `${kind.length}:${kind}${name.length}:${name}${size.toString().length}:${size}` +
+        `${mtimeNs.toString().length}:${mtimeNs}` +
+        (linkTarget === undefined ? "" : `${linkTarget.length}:${linkTarget}`) +
+        "\n",
+    );
+  };
+
+  const failed = (name: string): void => {
+    complete = false;
+    // Keep failures in the digest too: two incomplete walks should not happen
+    // to compare equal merely because they missed the same counters.
+    digest.update(`!incomplete:${name.length}:${name}\n`);
+  };
+
+  const walk = (dir: string, relative: string): void => {
     let d: Dir;
     try {
-      d = opendirSync(dir);
+      d = io.open(dir);
     } catch {
-      // An unreadable or missing directory must not abort the walk. The
-      // counters are left untouched; the deep verify is the authority anyway.
+      // An unreadable subdirectory means this fingerprint did not establish
+      // the source shape. Retaining a partial tuple here could make an older
+      // clean verification look current, so mark the walk incomplete.
+      failed(relative);
       return;
     }
     try {
+      const entries = [];
       let entry = d.readSync();
       while (entry !== null) {
+        entries.push(entry);
+        entry = d.readSync();
+      }
+      // Directory enumeration order is filesystem-dependent. Sorting names
+      // makes the digest stable across repeated walks and platforms.
+      entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+      for (const entry of entries) {
         const name = entry.name;
         if (!matchesAny(name, exclude)) {
           const p = join(dir, name);
-          if (entry.isDirectory()) {
-            walk(p);
-          } else if (entry.isFile()) {
-            try {
-              const st = statSync(p, { bigint: true });
+          const rel = relative === "" ? name : `${relative}/${name}`;
+          try {
+            // lstat is intentional: following a symlink would make a source
+            // alias disappear into the target tree and would omit the link
+            // itself from the evidence.
+            const st = io.lstat(p);
+            if (entry.isDirectory()) {
+              record("d", rel, st.size, st.mtimeNs);
+              walk(p, rel);
+            } else if (entry.isFile()) {
+              record("f", rel, st.size, st.mtimeNs);
               nfiles += 1;
               bytes += Number(st.size);
               if (st.mtimeNs > maxMtime) maxMtime = st.mtimeNs;
-            } catch {
-              // Vanished between readdir and stat; skip.
+            } else if (entry.isSymbolicLink()) {
+              // The link target is included in addition to the requested
+              // metadata fields so two links with the same length and mtime
+              // but different targets cannot collide.
+              record("l", rel, st.size, st.mtimeNs, io.readlink(p));
+              if (st.mtimeNs > maxMtime) maxMtime = st.mtimeNs;
+            } else {
+              // Rsync can preserve other directory entry types on some
+              // filesystems. Include them as evidence even though they are
+              // not part of the regular-file byte counters.
+              record("o", rel, st.size, st.mtimeNs);
+              if (st.mtimeNs > maxMtime) maxMtime = st.mtimeNs;
             }
+          } catch {
+            // A file can vanish between readdir and lstat. That is an
+            // incomplete observation, not an empty directory.
+            failed(rel);
           }
         }
-        entry = d.readSync();
       }
     } catch {
-      // Bun's opendirSync succeeds on a missing directory and raises ENOENT
-      // here instead, so the guard has to cover the read loop as well — a
-      // subdirectory that vanishes mid-walk must not crash a status run.
+      // A read failure part-way through the directory has the same meaning as
+      // an lstat failure: the counters are only a partial view.
+      failed(relative);
     } finally {
       try {
         d.closeSync();
@@ -86,10 +169,34 @@ export function fingerprint(root: string, exclude: readonly string[] = []): Fing
     }
   };
 
-  walk(root);
-  return { nfiles, bytes, maxMtimeNs: maxMtime.toString() };
+  // Preserve the established EMPTY value for a missing root. No unit can be
+  // verified without a source directory, and this keeps the public empty
+  // sentinel useful to callers that render an unconfigured source. A root
+  // that exists but cannot be walked falls through and is marked incomplete.
+  try {
+    io.lstat(root);
+  } catch {
+    return EMPTY;
+  }
+  walk(root, "");
+  return {
+    nfiles,
+    bytes,
+    maxMtimeNs: maxMtime.toString(),
+    digest: digest.digest("hex"),
+    complete,
+  };
 }
 
 export function sameFingerprint(a: Fingerprint, b: Fingerprint): boolean {
+  // An incomplete current walk proves nothing. This is the critical distinction
+  // from an empty, successfully walked directory.
+  if (a.complete === false || b.complete === false) return false;
+  // A generated fingerprint carries a digest. If only one side has one, the
+  // other side is an old record whose weaker tuple must not be accepted as
+  // evidence for a current source.
+  if (a.digest !== undefined || b.digest !== undefined) {
+    return a.digest !== undefined && b.digest !== undefined && a.digest === b.digest;
+  }
   return a.nfiles === b.nfiles && a.bytes === b.bytes && a.maxMtimeNs === b.maxMtimeNs;
 }

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -1,15 +1,11 @@
 import { type Dirent, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { Config, Target } from "./config.ts";
-import {
-  buildDiffFromAccumulator,
-  createDiffAccumulator,
-  type Diff,
-} from "./diff.ts";
+import { buildDiffFromAccumulator, createDiffAccumulator, type Diff } from "./diff.ts";
 import { type Fingerprint, fingerprint } from "./fingerprint.ts";
 import { isNew, parseItemizeLine } from "./itemize.ts";
 import { logDir } from "./paths.ts";
-import { argvFor, RsyncError, type Mode, runRsync } from "./rsync.ts";
+import { argvFor, type Mode, RsyncError, runRsync } from "./rsync.ts";
 import { checkSentinel, readSentinel, type SentinelStatus } from "./sentinel.ts";
 import type { Method, Scan } from "./state.ts";
 import { checkVolume, identifySync } from "./volume.ts";
@@ -102,9 +98,7 @@ export class TargetCheckError extends RsyncError {
   readonly reachability: FailedReachability;
 
   constructor(target: Target, reachability: FailedReachability) {
-    super(
-      `refusing to check: destination ${target.name} is ${reachability} at ${target.path}`,
-    );
+    super(`refusing to check: destination ${target.name} is ${reachability} at ${target.path}`);
     this.name = "TargetCheckError";
     this.targetName = target.name;
     this.reachability = reachability;

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -1,13 +1,18 @@
 import { type Dirent, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { Config, Target } from "./config.ts";
+import {
+  buildDiffFromAccumulator,
+  createDiffAccumulator,
+  type Diff,
+} from "./diff.ts";
 import { type Fingerprint, fingerprint } from "./fingerprint.ts";
-import { type Item, parseItemizeLine, summarize } from "./itemize.ts";
+import { isNew, parseItemizeLine } from "./itemize.ts";
 import { logDir } from "./paths.ts";
-import { argvFor, type Mode, runRsync } from "./rsync.ts";
-import { checkSentinel, type SentinelStatus } from "./sentinel.ts";
+import { argvFor, RsyncError, type Mode, runRsync } from "./rsync.ts";
+import { checkSentinel, readSentinel, type SentinelStatus } from "./sentinel.ts";
 import type { Method, Scan } from "./state.ts";
-import { checkVolume } from "./volume.ts";
+import { checkVolume, identifySync } from "./volume.ts";
 
 /** Units are the immediate subfolders of the source root. Not a depth, not a list. */
 export function listUnits(source: string): string[] {
@@ -76,6 +81,74 @@ export async function targetReachability(target: Target): Promise<Reachability> 
 }
 
 /**
+ * Final write-boundary reachability check.
+ *
+ * The interactive ledger's reachability map is intentionally cached and may
+ * be minutes old while a person reads the confirmation page. A sync must not
+ * reuse that answer. This version reads the current mount table and identity
+ * synchronously so `startSync` can run it immediately before `Bun.spawn`.
+ */
+export interface TargetObservation {
+  readonly reachability: Reachability;
+  /** Identity actually observed at the destination, or empty when absent. */
+  readonly identity: string;
+}
+
+export type FailedReachability = Exclude<Reachability, "ok">;
+
+/** A queued check reached its own fresh boundary and found no safe target. */
+export class TargetCheckError extends RsyncError {
+  readonly targetName: string;
+  readonly reachability: FailedReachability;
+
+  constructor(target: Target, reachability: FailedReachability) {
+    super(
+      `refusing to check: destination ${target.name} is ${reachability} at ${target.path}`,
+    );
+    this.name = "TargetCheckError";
+    this.targetName = target.name;
+    this.reachability = reachability;
+  }
+}
+
+function assertTargetReachable(
+  target: Target,
+  observation: TargetObservation,
+): asserts observation is TargetObservation & { readonly reachability: "ok" } {
+  if (observation.reachability !== "ok") {
+    throw new TargetCheckError(target, observation.reachability);
+  }
+}
+
+/** Fresh destination observation, with the provenance to stamp on a scan. */
+export function observeTargetSync(target: Target): TargetObservation {
+  if (target.identity !== undefined && target.identity !== "") {
+    const found = identifySync(target.path);
+    if (found === null) return { reachability: "unreachable", identity: "" };
+    if (found.id !== target.identity) return { reachability: "mismatch", identity: found.id };
+    if (!existsSync(target.path)) return { reachability: "unreachable", identity: found.id };
+    if (identityIsProof(target) || target.sentinel === undefined) {
+      return { reachability: "ok", identity: found.id };
+    }
+    return {
+      reachability: checkSentinel(target.path, target.sentinel),
+      identity: found.id,
+    };
+  }
+  if (!existsSync(target.path)) return { reachability: "unreachable", identity: "" };
+  if (target.sentinel === undefined) return { reachability: "missing", identity: "" };
+  const actual = readSentinel(target.path);
+  return {
+    reachability: actual === null ? "missing" : actual === target.sentinel ? "ok" : "mismatch",
+    identity: actual ?? "",
+  };
+}
+
+export function targetReachabilitySync(target: Target): Reachability {
+  return observeTargetSync(target).reachability;
+}
+
+/**
  * Whether a target's recorded identity names the volume, or merely where it
  * was plugged in this time.
  *
@@ -104,7 +177,8 @@ export async function allReachability(config: Config): Promise<Map<string, Reach
 
 export interface CheckResult {
   readonly scan: Scan;
-  readonly items: readonly Item[];
+  /** Bounded, streaming diff evidence from the itemize output. */
+  readonly diff: Diff;
   /**
    * What is actually at the destination: a read-only walk of the target folder.
    *
@@ -159,21 +233,40 @@ export async function checkUnit(
   const now = opts.now ?? Date.now();
   const startedAt = Date.now();
   const fp = opts.fingerprint ?? fingerprint(join(config.source, unit), config.exclude);
-  const base = {
-    unit,
-    target: target.name,
-    ts: now,
-    method: methodOf(mode),
-    fingerprint: fp,
-    sentinel: target.identity ?? target.sentinel ?? "",
-  } as const;
+
+  // The reachability map belongs to the ledger refresh and may be stale by
+  // the time this queued check gets its turn. Establish that the destination
+  // is still the recorded volume before even reading its unit. This also keeps
+  // an unmounted path from being mistaken for a legitimate "missing" folder.
+  const initialObservation = observeTargetSync(target);
+  assertTargetReachable(target, initialObservation);
+
+  const accumulator = createDiffAccumulator();
 
   // Nothing at the destination at all: report it directly rather than letting
   // rsync itemize the entire tree as pending.
   if (!existsSync(join(target.path, unit))) {
+    // The observation used for the record is taken after the existence check,
+    // so a target replaced while the queued job waited cannot stamp the old
+    // identity into a new "missing" result.
+    const observation = observeTargetSync(target);
+    assertTargetReachable(target, observation);
+    const base = {
+      unit,
+      target: target.name,
+      ts: now,
+      method: methodOf(mode),
+      fingerprint: fp,
+      sentinel: observation.identity,
+    } as const;
+    const diff = buildDiffFromAccumulator(unit, target.name, methodOf(mode), accumulator, {
+      ts: now,
+      wholeFolderMissing: true,
+      source: fp,
+    });
     return {
       scan: { ...base, outcome: "missing", nChanges: 0, nExtra: 0, bytesPending: 0 },
-      items: [],
+      diff,
       argv: [],
       targetFingerprint: null,
       exitCode: null,
@@ -181,11 +274,25 @@ export async function checkUnit(
   }
 
   const argv = argvFor(config, unit, target, mode);
-  const items: Item[] = [];
-  // Counted as we go rather than by filtering `items` on every line: that
-  // filter was O(n) per line, so a 40,000-file folder spent 800 million
-  // comparisons re-deriving a number it could have incremented.
+  // This is deliberately the last destination operation before runRsync.
+  // Every check must re-read the mount table/identity at its own write-free
+  // boundary: another queued check may have occupied the time since the map
+  // was built, and a drive can be swapped during that interval.
+  const observation = observeTargetSync(target);
+  assertTargetReachable(target, observation);
+  const base = {
+    unit,
+    target: target.name,
+    ts: now,
+    method: methodOf(mode),
+    fingerprint: fp,
+    sentinel: observation.identity,
+  } as const;
   let nFiles = 0;
+  let nChanges = 0;
+  let nNew = 0;
+  let nExtra = 0;
+  let bytesPending = 0;
   const result = await runRsync(argv, {
     ...(opts.bin !== undefined ? { bin: opts.bin } : {}),
     ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
@@ -193,7 +300,15 @@ export async function checkUnit(
       opts.onLine?.(line);
       const item = parseItemizeLine(line);
       if (item === null) return;
-      items.push(item);
+      accumulator.add(item);
+      if (item.kind === "extra") {
+        nExtra += 1;
+      } else if (item.kind === "change") {
+        nChanges += 1;
+        if (isNew(item)) nNew += 1;
+        // Directories carry a size but transfer no file content.
+        if (item.flags[1] === "f") bytesPending += item.bytes;
+      }
       // Directories are not files; counting them would overshoot the total.
       if (item.flags[1] === "f") {
         nFiles += 1;
@@ -213,7 +328,10 @@ export async function checkUnit(
   if (result.exitCode !== 0 && result.exitCode !== 24) {
     return {
       scan: { ...base, outcome: "error", nChanges: 0, nExtra: 0, bytesPending: 0 },
-      items,
+      diff: buildDiffFromAccumulator(unit, target.name, methodOf(mode), accumulator, {
+        ts: now,
+        source: fp,
+      }),
       argv,
       targetFingerprint: null,
       exitCode: result.exitCode,
@@ -223,19 +341,22 @@ export async function checkUnit(
   // After rsync, not before: the walk is read-only and cheap next to a check,
   // but doing it first would delay the run for a number only shown afterwards.
   const targetFingerprint = fingerprint(join(target.path, unit), config.exclude);
-
-  const s = summarize(items);
+  const diff = buildDiffFromAccumulator(unit, target.name, methodOf(mode), accumulator, {
+    ts: now,
+    source: fp,
+    target: targetFingerprint,
+  });
   return {
     scan: {
       ...base,
       durationMs: Date.now() - startedAt,
-      outcome: s.nChanges === 0 ? "clean" : "behind",
-      nChanges: s.nChanges,
-      nNew: s.nNew,
-      nExtra: s.nExtra,
-      bytesPending: s.bytesPending,
+      outcome: nChanges === 0 ? "clean" : "behind",
+      nChanges,
+      nNew,
+      nExtra,
+      bytesPending,
     },
-    items,
+    diff,
     argv,
     targetFingerprint,
     exitCode: result.exitCode,

--- a/src/state.ts
+++ b/src/state.ts
@@ -104,9 +104,15 @@ function validateScan(raw: unknown): Scan | string {
   const nfiles = fp["nfiles"];
   const bytes = fp["bytes"];
   const maxMtimeNs = fp["maxMtimeNs"];
+  const digest = fp["digest"];
+  const complete = fp["complete"];
   if (typeof nfiles !== "number") return "fingerprint.nfiles is not a number";
   if (typeof bytes !== "number") return "fingerprint.bytes is not a number";
   if (typeof maxMtimeNs !== "string") return "fingerprint.maxMtimeNs is not a string";
+  if (digest !== undefined && typeof digest !== "string")
+    return "fingerprint.digest is not a string";
+  if (complete !== undefined && typeof complete !== "boolean")
+    return "fingerprint.complete is not a boolean";
 
   if (nNew !== undefined && typeof nNew !== "number") return "nNew is not a number";
   if (durationMs !== undefined && typeof durationMs !== "number")
@@ -122,7 +128,13 @@ function validateScan(raw: unknown): Scan | string {
     nChanges,
     nExtra,
     bytesPending,
-    fingerprint: { nfiles, bytes, maxMtimeNs },
+    fingerprint: {
+      nfiles,
+      bytes,
+      maxMtimeNs,
+      ...(digest !== undefined ? { digest } : {}),
+      ...(complete !== undefined ? { complete } : {}),
+    },
     sentinel,
     ...(nNew !== undefined ? { nNew } : {}),
     ...(durationMs !== undefined ? { durationMs } : {}),

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -4,7 +4,7 @@ import { type Config, canonicalPath, containmentError, type Target } from "./con
 import { type Item, parseItemizeLine } from "./itemize.ts";
 import { debug } from "./log.ts";
 import { argvFor, assertDeleteIsDryRun, DEFAULT_RSYNC, RsyncError } from "./rsync.ts";
-import { ensureLogDir } from "./scan.ts";
+import { ensureLogDir, targetReachabilitySync } from "./scan.ts";
 import { appendHistory } from "./state.ts";
 
 /**
@@ -113,7 +113,18 @@ export function startSync(
   // as far as spawning if the invariant is broken.
   assertDeleteIsDryRun(argv);
 
+  // Confirmation can sit on screen while a drive is unplugged or replaced.
+  // This is deliberately uncached and immediately before the only spawn that
+  // can write to a destination; the ledger's earlier reachability result is
+  // only a display hint, never permission to write.
   assertRuntimeContainment(config, target);
+  const reach = targetReachabilitySync(target);
+  if (reach !== "ok") {
+    throw new RsyncError(
+      `refusing to sync: destination ${target.name} is ${reach} — refusing to write to ${target.path}`,
+    );
+  }
+
   const logPath = opts.logPath ?? syncLogPath(unit, target.name, now);
   assertLogPath(logPath);
   appendHistory({ ts: now, unit, target: target.name, argv, exitCode: null, log: logPath });

--- a/src/tui/useJob.ts
+++ b/src/tui/useJob.ts
@@ -2,14 +2,14 @@ import { join } from "node:path";
 import { useEffect, useState } from "react";
 import type { Config } from "../config.ts";
 import { saveDiff } from "../diff.ts";
-import { fingerprint, type Fingerprint } from "../fingerprint.ts";
+import { type Fingerprint, fingerprint } from "../fingerprint.ts";
 import { debug } from "../log.ts";
 import {
   allReachability,
   checkUnit,
   methodOf,
-  TargetCheckError,
   type Reachability,
+  TargetCheckError,
 } from "../scan.ts";
 import { appendHistory, estimateMs, type State, saveState, upsertScan } from "../state.ts";
 import { reachWord } from "../status.ts";

--- a/src/tui/useJob.ts
+++ b/src/tui/useJob.ts
@@ -1,9 +1,16 @@
+import { join } from "node:path";
 import { useEffect, useState } from "react";
 import type { Config } from "../config.ts";
-import { buildDiff, saveDiff } from "../diff.ts";
-import type { Fingerprint } from "../fingerprint.ts";
+import { saveDiff } from "../diff.ts";
+import { fingerprint, type Fingerprint } from "../fingerprint.ts";
 import { debug } from "../log.ts";
-import { allReachability, checkUnit, methodOf, type Reachability } from "../scan.ts";
+import {
+  allReachability,
+  checkUnit,
+  methodOf,
+  TargetCheckError,
+  type Reachability,
+} from "../scan.ts";
 import { appendHistory, estimateMs, type State, saveState, upsertScan } from "../state.ts";
 import { reachWord } from "../status.ts";
 import type { Row } from "./Ledger.tsx";
@@ -48,6 +55,33 @@ export interface Job {
   /** The transient status line under the ledger, or null when idle. */
   readonly busy: string | null;
   readonly runCheck: (mode: "quick" | "deep", scope: "selected" | "all") => Promise<void>;
+}
+
+/**
+ * Returns one source fingerprint for a unit during a queued run.
+ *
+ * The opening refresh usually provides the cache. The fallback matters when a
+ * key arrives before that refresh resolves: without it, a run over two
+ * destinations would walk the same source twice before either check starts.
+ * Keeping this small seam separate also makes the one-walk invariant directly
+ * testable without rendering a terminal or spawning rsync.
+ */
+export function cachedSourceFingerprint(
+  config: Pick<Config, "source" | "exclude">,
+  unit: string,
+  cache: Map<string, Fingerprint>,
+  read: typeof fingerprint = fingerprint,
+): Fingerprint {
+  const existing = cache.get(unit);
+  if (existing !== undefined) return existing;
+  const current = read(join(config.source, unit), config.exclude);
+  cache.set(unit, current);
+  return current;
+}
+
+/** Counts jobs that were not skipped; displayed skip reasons are deduplicated. */
+export function jobsRan(totalJobs: number, skippedJobs: number): number {
+  return Math.max(0, totalJobs - skippedJobs);
 }
 
 export function useJob(facts: JobFacts): Job {
@@ -118,11 +152,20 @@ export function useJob(facts: JobFacts): Job {
     let done = 0;
     let bytesDone = 0;
 
+    // A refresh normally supplies this map. If the user starts a check while
+    // the first reachability refresh is still in flight, however, `scan` is
+    // null and checkUnit would otherwise walk the same source once per target.
+    // Keep the per-run fallback here so a multi-target check has exactly one
+    // source fingerprint per unit in either case.
+    const sourceFingerprints = new Map(facts.scan?.fingerprints ?? []);
+
     // Destinations that could not be reached, so the run can say what it did
     // not do. Skipping in silence and then reporting "deep check finished"
     // was a claim that nothing had been checked — indistinguishable from a
     // check that never started.
     const skipped: { readonly target: string; readonly why: Reachability }[] = [];
+    let skippedJobs = 0;
+    const failed: { readonly unit: string; readonly target: string }[] = [];
 
     for (const job of jobs) {
       // Nothing to report and nobody to report it to: the interface has
@@ -143,6 +186,7 @@ export function useJob(facts: JobFacts): Job {
         });
         done += 1;
         bytesDone += job.size;
+        skippedJobs += 1;
         continue;
       }
       // Estimated from measured throughput at this destination, so the bar
@@ -173,14 +217,19 @@ export function useJob(facts: JobFacts): Job {
         files: job.files,
         estimateMs: prior ?? null,
       });
+      const cachedFingerprint = cachedSourceFingerprint(facts.config, job.unit, sourceFingerprints);
       try {
-        const { scan, argv, items, targetFingerprint, exitCode } = await checkUnit(
+        const { scan, diff, argv, exitCode } = await checkUnit(
           facts.config,
           job.unit,
           job.target,
           mode,
           {
             signal: quitting.signal,
+            // The refresh snapshot already paid for this metadata walk. Pass
+            // it through so each target does not fingerprint the same source
+            // unit again while a queue is running.
+            ...(cachedFingerprint === undefined ? {} : { fingerprint: cachedFingerprint }),
             // Throttled: one render per 25 files keeps a large folder from
             // driving the render loop instead of the check.
             onFile: (seen) => {
@@ -212,17 +261,10 @@ export function useJob(facts: JobFacts): Job {
         });
         working = upsertScan(working, scan);
         saveState(working);
-        // The itemized list is what the differences screen shows. rsync
-        // produced it during the check; discarding it would mean re-running
-        // the whole check to answer "which files?".
-        saveDiff(
-          buildDiff(job.unit, job.target.name, scan.method, items, {
-            ts: scan.ts,
-            wholeFolderMissing: scan.outcome === "missing",
-            source: scan.fingerprint,
-            target: targetFingerprint,
-          }),
-        );
+        // The itemized list is accumulated during the rsync stream and capped
+        // before it reaches this queue. Saving it here does not retain the
+        // full output or map it into a second unbounded array.
+        saveDiff(diff);
         appendHistory({
           ts: scan.ts,
           unit: job.unit,
@@ -236,15 +278,32 @@ export function useJob(facts: JobFacts): Job {
         facts.setNow(Date.now());
       } catch (e) {
         if (quitting.signal.aborted) return;
-        // Explicit catch at the subprocess boundary; a swallowed rejection
-        // would leave the ledger showing stale state as if it were fresh.
-        debug("check.failed", {
-          unit: job.unit,
-          target: job.target.name,
-          ms: Date.now() - jobStarted,
-          error: (e as Error).message,
-        });
-        setBusy(`${job.unit} → ${job.target.name}: failed — ${(e as Error).message}`);
+        if (e instanceof TargetCheckError) {
+          // A destination can change while an earlier queued check is
+          // running. Treat that job as a named skip, not a transient failure:
+          // the final line must not be overwritten by "check finished".
+          if (!skipped.some((s) => s.target === e.targetName)) {
+            skipped.push({ target: e.targetName, why: e.reachability });
+          }
+          debug("check.skipped", {
+            unit: job.unit,
+            target: e.targetName,
+            reach: e.reachability,
+            fresh: true,
+          });
+          skippedJobs += 1;
+        } else {
+          failed.push({ unit: job.unit, target: job.target.name });
+          // Explicit catch at the subprocess boundary; a swallowed rejection
+          // would leave the ledger showing stale state as if it were fresh.
+          debug("check.failed", {
+            unit: job.unit,
+            target: job.target.name,
+            ms: Date.now() - jobStarted,
+            error: (e as Error).message,
+          });
+          setBusy(`${job.unit} → ${job.target.name}: failed — ${(e as Error).message}`);
+        }
       }
       done += 1;
       bytesDone += job.size;
@@ -256,9 +315,10 @@ export function useJob(facts: JobFacts): Job {
     facts.refresh();
     // A run in which every destination was skipped checked nothing, and must
     // not report otherwise.
-    const ran =
-      jobs.length -
-      skipped.reduce((n, s) => n + jobs.filter((j) => j.target.name === s.target).length, 0);
+    // `skipped` is deduplicated for the human-facing message, so it cannot
+    // also count work: a target may complete one queued unit before becoming
+    // unavailable for the next. Count the actual skipped jobs at the boundary.
+    const ran = jobsRan(jobs.length, skippedJobs);
     if (ran === 0 && skipped.length > 0) {
       setBusy(
         `nothing checked — ${skipped.map((s) => `${s.target} ${reachWord(s.why)}`).join(", ")}`,
@@ -267,6 +327,11 @@ export function useJob(facts: JobFacts): Job {
       setBusy(
         `${mode} check finished · ${ran} of ${jobs.length} · skipped ` +
           skipped.map((s) => `${s.target} (${reachWord(s.why)})`).join(", "),
+      );
+    } else if (failed.length > 0) {
+      setBusy(
+        `${mode} check finished · ${jobs.length - failed.length} of ${jobs.length} · ` +
+          `failed ${failed.map((f) => `${f.target}/${f.unit}`).join(", ")}`,
       );
     } else {
       setBusy(

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -407,10 +407,7 @@ export async function identify(
  * the rsync boundary would turn a stale confirmation into permission to write
  * to whatever now occupies the configured path.
  */
-export function identifySync(
-  path: string,
-  entries?: readonly MountEntry[],
-): VolumeIdentity | null {
+export function identifySync(path: string, entries?: readonly MountEntry[]): VolumeIdentity | null {
   const table = entries ?? readMountTableSync();
   const entry = mountFor(path, table);
   if (entry === undefined) return null;

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -89,6 +89,30 @@ async function volumeUuid(entry: MountEntry): Promise<string | null> {
 }
 
 /**
+ * Synchronous counterpart used at the write boundary.
+ *
+ * The normal status path deliberately caches mount discovery and awaits
+ * diskutil. A transfer cannot use that cache: a drive may have been removed
+ * while the confirmation screen was open. `startSync` calls this immediately
+ * before spawning rsync, so it reads the OS's current mount table and volume
+ * identity in the same synchronous turn as the spawn.
+ */
+function volumeUuidSync(entry: MountEntry): string | null {
+  if (IS_LINUX) return volumeUuidLinux(entry);
+  try {
+    const result = Bun.spawnSync(["/usr/sbin/diskutil", "info", entry.mountPoint]);
+    const out =
+      typeof result.stdout === "string"
+        ? result.stdout
+        : new TextDecoder().decode(result.stdout as Uint8Array);
+    const m = /Volume UUID:\s*([0-9A-Fa-f-]{8,})/.exec(out);
+    return m?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The three filesystem questions the Linux volume code asks the kernel.
  *
  * Injectable as one object so the decisions built on top can be tested
@@ -299,6 +323,22 @@ async function readMountTable(): Promise<MountEntry[]> {
   return parseMount(out);
 }
 
+/** Reads the mount table without the short-lived cache. */
+function readMountTableSync(): MountEntry[] {
+  mountTableReadCount++;
+  if (IS_LINUX) return parseProcMounts(readFileSync("/proc/mounts", "utf8"));
+  try {
+    const result = Bun.spawnSync(["/sbin/mount"]);
+    const out =
+      typeof result.stdout === "string"
+        ? result.stdout
+        : new TextDecoder().decode(result.stdout as Uint8Array);
+    return parseMount(out);
+  } catch {
+    return [];
+  }
+}
+
 function mountTable(): Promise<MountEntry[]> {
   const hit = mountCache;
   if (hit !== null && Date.now() - hit.at < MOUNT_TABLE_TTL_MS) return hit.table;
@@ -359,6 +399,31 @@ export async function identify(
     : { id: uuid, kind: "volume-uuid", mountPoint: entry.mountPoint, fstype };
 }
 
+/**
+ * Identifies a destination for a write without using the mount-table cache.
+ *
+ * This intentionally mirrors `identify` rather than warming or invalidating
+ * its cache: the cached path is useful for a status refresh, but reusing it at
+ * the rsync boundary would turn a stale confirmation into permission to write
+ * to whatever now occupies the configured path.
+ */
+export function identifySync(
+  path: string,
+  entries?: readonly MountEntry[],
+): VolumeIdentity | null {
+  const table = entries ?? readMountTableSync();
+  const entry = mountFor(path, table);
+  if (entry === undefined) return null;
+  const fstype = entry.fstype;
+  if (isNetwork(fstype)) {
+    return { id: entry.device, kind: "mount-source", mountPoint: entry.mountPoint, fstype };
+  }
+  const uuid = volumeUuidSync(entry);
+  return uuid === null
+    ? { id: entry.device, kind: "mount-source", mountPoint: entry.mountPoint, fstype }
+    : { id: uuid, kind: "volume-uuid", mountPoint: entry.mountPoint, fstype };
+}
+
 export type VolumeStatus = "ok" | "mismatch" | "unreachable";
 
 /**
@@ -370,6 +435,13 @@ export type VolumeStatus = "ok" | "mismatch" | "unreachable";
  */
 export async function checkVolume(path: string, expected: string): Promise<VolumeStatus> {
   const found = await identify(path);
+  if (found === null) return "unreachable";
+  return found.id === expected ? "ok" : "mismatch";
+}
+
+/** Fresh, uncached identity comparison for the final pre-spawn guard. */
+export function checkVolumeSync(path: string, expected: string): VolumeStatus {
+  const found = identifySync(path);
   if (found === null) return "unreachable";
   return found.id === expected ? "ok" : "mismatch";
 }

--- a/test/fingerprint.test.ts
+++ b/test/fingerprint.test.ts
@@ -1,7 +1,21 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  lstatSync,
+  mkdirSync,
+  opendirSync,
+  readlinkSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
-import { EMPTY, fingerprint, matchesAny, sameFingerprint } from "../src/fingerprint.ts";
+import {
+  EMPTY,
+  fingerprint,
+  matchesAny,
+  sameFingerprint,
+  type FingerprintIo,
+} from "../src/fingerprint.ts";
 import { makeFixtureDir, removeFixtureDir } from "./helpers.ts";
 
 let dir: string;
@@ -83,6 +97,59 @@ describe("fingerprint", () => {
     const fp = fingerprint(dir);
     expect(typeof fp.maxMtimeNs).toBe("string");
     expect(BigInt(fp.maxMtimeNs) > 0n).toBe(true);
+  });
+
+  test("distinguishes different paths with the same legacy tuple", () => {
+    const first = write("first/a.txt", "x");
+    const second = write("second/b.txt", "x");
+    const fixed = new Date(Date.now() + 60_000);
+    utimesSync(first, fixed, fixed);
+    utimesSync(second, fixed, fixed);
+    utimesSync(join(dir, "first"), fixed, fixed);
+    utimesSync(join(dir, "second"), fixed, fixed);
+    const a = fingerprint(join(dir, "first"));
+    const b = fingerprint(join(dir, "second"));
+    expect([a.nfiles, a.bytes, a.maxMtimeNs]).toEqual([b.nfiles, b.bytes, b.maxMtimeNs]);
+    expect(a.digest).not.toBe(b.digest);
+    expect(sameFingerprint(a, b)).toBe(false);
+  });
+
+  test("includes symlinks in the tree evidence", () => {
+    write("with/target.txt", "x");
+    symlinkSync("target.txt", join(dir, "with/link"));
+    write("without/target.txt", "x");
+    const fixed = new Date(Date.now() + 60_000);
+    utimesSync(join(dir, "with/target.txt"), fixed, fixed);
+    utimesSync(join(dir, "without/target.txt"), fixed, fixed);
+    utimesSync(join(dir, "with"), fixed, fixed);
+    utimesSync(join(dir, "without"), fixed, fixed);
+    const withLink = fingerprint(join(dir, "with"));
+    const withoutLink = fingerprint(join(dir, "without"));
+    expect(withLink.nfiles).toBe(withoutLink.nfiles);
+    expect(withLink.bytes).toBe(withoutLink.bytes);
+    expect(sameFingerprint(withLink, withoutLink)).toBe(false);
+  });
+
+  test("an incomplete walk can never count as unchanged evidence", () => {
+    const good = fingerprint(dir);
+    expect(sameFingerprint({ ...good, complete: false }, good)).toBe(false);
+  });
+
+  test("an unreadable directory is marked incomplete through the filesystem seam", () => {
+    write("visible.txt", "x");
+    write("blocked/hidden.txt", "y");
+    const io: FingerprintIo = {
+      lstat: (path) => lstatSync(path, { bigint: true }),
+      open: (path) => {
+        if (path === join(dir, "blocked")) throw new Error("simulated read failure");
+        return opendirSync(path);
+      },
+      readlink: (path) => readlinkSync(path),
+    };
+    const incomplete = fingerprint(dir, [], io);
+    expect(incomplete.complete).toBe(false);
+    expect(incomplete.nfiles).toBe(1);
+    expect(sameFingerprint(incomplete, fingerprint(dir))).toBe(false);
   });
 });
 

--- a/test/fingerprint.test.ts
+++ b/test/fingerprint.test.ts
@@ -11,10 +11,10 @@ import {
 import { join } from "node:path";
 import {
   EMPTY,
+  type FingerprintIo,
   fingerprint,
   matchesAny,
   sameFingerprint,
-  type FingerprintIo,
 } from "../src/fingerprint.ts";
 import { makeFixtureDir, removeFixtureDir } from "./helpers.ts";
 

--- a/test/job.test.ts
+++ b/test/job.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { cachedSourceFingerprint, jobsRan } from "../src/tui/useJob.ts";
+import type { Fingerprint } from "../src/fingerprint.ts";
+
+const FP: Fingerprint = {
+  nfiles: 2,
+  bytes: 8,
+  maxMtimeNs: "1",
+  digest: "source-digest",
+  complete: true,
+};
+
+describe("queued checks cache source fingerprints", () => {
+  test("walks a unit once even when multiple destinations request it", () => {
+    const calls: string[] = [];
+    const cache = new Map<string, Fingerprint>();
+    const config = { source: "/source", exclude: [".DS_Store"] };
+    const read = (path: string): Fingerprint => {
+      calls.push(path);
+      return FP;
+    };
+
+    expect(cachedSourceFingerprint(config, "photos", cache, read)).toBe(FP);
+    expect(cachedSourceFingerprint(config, "photos", cache, read)).toBe(FP);
+
+    expect(calls).toEqual(["/source/photos"]);
+  });
+
+  test("walks different units independently", () => {
+    const calls: string[] = [];
+    const cache = new Map<string, Fingerprint>();
+    const config = { source: "/source", exclude: [] as readonly string[] };
+    const read = (path: string): Fingerprint => {
+      calls.push(path);
+      return FP;
+    };
+
+    cachedSourceFingerprint(config, "a", cache, read);
+    cachedSourceFingerprint(config, "b", cache, read);
+
+    expect(calls).toEqual(["/source/a", "/source/b"]);
+  });
+
+  test("counts a completed unit when a later unit shares its skipped target", () => {
+    // Two queued units produce one displayed target reason. The old target
+    // based subtraction called both units skipped; only the second job was.
+    expect(jobsRan(2, 1)).toBe(1);
+  });
+});

--- a/test/job.test.ts
+++ b/test/job.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { cachedSourceFingerprint, jobsRan } from "../src/tui/useJob.ts";
 import type { Fingerprint } from "../src/fingerprint.ts";
+import { cachedSourceFingerprint, jobsRan } from "../src/tui/useJob.ts";
 
 const FP: Fingerprint = {
   nfiles: 2,

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { type Config, parseConfig, type Target } from "../src/config.ts";
+import { MAX_ENTRIES } from "../src/diff.ts";
 import { checkUnit } from "../src/scan.ts";
 import { appendHistory } from "../src/state.ts";
+import { SENTINEL_NAME } from "../src/sentinel.ts";
 import { makeFixtureDir, removeFixtureDir } from "./helpers.ts";
 
 /**
@@ -51,6 +53,7 @@ function setUpUnit(config: Config): Target {
   mkdirSync(join(config.source, "photos"), { recursive: true });
   const target = config.targets[0]!;
   mkdirSync(join(target.path, "photos"), { recursive: true });
+  writeFileSync(join(target.path, SENTINEL_NAME), `${target.sentinel}\n`);
   return target;
 }
 
@@ -128,5 +131,22 @@ describe("exit 24 — files vanished mid-walk — is not an error", () => {
     });
     expect(scan.outcome).toBe("behind");
     expect(scan.nChanges).toBe(1);
+  });
+});
+
+describe("itemize output is accumulated with bounded memory", () => {
+  test("retains only the display cap while keeping exact totals", async () => {
+    const config = makeConfig();
+    const target = setUpUnit(config);
+    const total = MAX_ENTRIES + 250;
+    const lines = Array.from({ length: total }, (_, i) => `>f+++++++++|1|file-${i}.txt`);
+    const result = await checkUnit(config, "photos", target, "quick", {
+      bin: fakeRsync(0, lines),
+    });
+    expect(result.diff.entries).toHaveLength(MAX_ENTRIES);
+    expect(result.diff.truncated).toBe(250);
+    expect(result.diff.totals?.new).toBe(total);
+    expect(result.scan.nChanges).toBe(total);
+    expect(result).not.toHaveProperty("items");
   });
 });

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { type Config, parseConfig, type Target } from "../src/config.ts";
 import { MAX_ENTRIES } from "../src/diff.ts";
 import { checkUnit } from "../src/scan.ts";
-import { appendHistory } from "../src/state.ts";
 import { SENTINEL_NAME } from "../src/sentinel.ts";
+import { appendHistory } from "../src/state.ts";
 import { makeFixtureDir, removeFixtureDir } from "./helpers.ts";
 
 /**

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -221,6 +221,12 @@ describeRsync("startSync", () => {
     ).toThrow(/outside/);
   });
 
+  test("rechecks the destination proof immediately before spawning", () => {
+    writeFileSync(join(target().path, SENTINEL_NAME), "different-volume\n");
+    expect(() => startSync(config, "photos-2019", target())).toThrow(/refusing to sync/);
+    expect(existsSync(join(target().path, "photos-2019"))).toBe(false);
+  });
+
   test("copies the unit to the target", async () => {
     const h = startSync(config, "photos-2019", target());
     const r = await h.done;

--- a/test/write-policy.test.ts
+++ b/test/write-policy.test.ts
@@ -179,6 +179,10 @@ describeRsync("everything that lands in a target arrives via rsync", () => {
     const config: Config = parseConfig(
       `source = "${join(root, "src")}"\n[[target]]\nname="dst"\npath="${join(root, "dst")}"\nsentinel="s"\n`,
     );
+    // The executor now performs the same final destination proof as the real
+    // app. Seed the fixture through the normal rsync-owned sentinel path before
+    // asserting that it does not pre-create the unit directory.
+    await writeSentinel(join(root, "dst"), { id: "s" });
     const dest = join(root, "dst", "unit-a");
     expect(existsSync(dest)).toBe(false);
     const h = startSync(config, "unit-a", target());


### PR DESCRIPTION
Closes #18.

## What changed

- Add a deterministic SHA-256 digest over sorted relative paths, entry types, sizes, mtimes, and symlink targets.
- Mark interrupted or unreadable walks incomplete so partial observations cannot preserve verified evidence.
- Keep legacy fingerprints readable while refusing to equate weak legacy evidence with a new digest.
- Validate the added fingerprint fields when state is loaded.

## Verification

- `bun test` — 893 passed, 0 failed
- `bunx tsc --noEmit`
- `bun run build`
- `bun run audit`

## Stack

Depends on the issue #17 PR; this PR contains only the fingerprint-evidence commit.
